### PR TITLE
CHECKOUT-1051: Export factory function

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ bigpay-client.js is a client-side library for posting payment data to Bigpay.
 
 In `checkout.js`
 ```{js}
-import BigpayClient from 'bigpay-client';
+import { createClient } from 'bigpay-client';
 import { getPaymentData } from './payment';
 
-const bigpayClient = new BigpayClient({
+const bigpayClient = createClient({
     host: 'https://payments.bigcommerce.com',
 });
 

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -1,6 +1,6 @@
-import { PAYMENT_TYPES, initializeOffsitePayment, submitPayment } from './payment';
+import { PAYMENT_TYPES, initializeOffsitePayment, submitPayment } from '../payment';
 
-export default class BigpayClient {
+export default class Client {
     /**
      * Construct BigpayClient
      * @param {Object} config

--- a/src/client/create-client.js
+++ b/src/client/create-client.js
@@ -1,0 +1,10 @@
+import Client from './client';
+
+/**
+ * Create client
+ * @param {Object} config
+ * @returns {Client}
+ */
+export function createClient(config) {
+    return new Client(config);
+}

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,0 +1,5 @@
+import createClient from './create-client';
+
+export {
+    createClient,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,5 @@
+import { createClient } from './client';
+
+export {
+    createClient,
+};

--- a/test/client/client.spec.js
+++ b/test/client/client.spec.js
@@ -1,10 +1,10 @@
 import cloneDeep from 'lodash/cloneDeep';
-import { HOSTED } from '../src/payment/payment-types';
-import * as paymentModule from '../src/payment';
-import BigpayClient from '../src/bigpay-client';
-import paymentRequestDataMock from './mocks/payment-request-data';
+import { HOSTED } from '../../src/payment/payment-types';
+import * as paymentModule from '../../src/payment';
+import Client from '../../src/client/client';
+import paymentRequestDataMock from '../mocks/payment-request-data';
 
-describe('BigpayClient', () => {
+describe('Client', () => {
     let bigpayClient;
     let config;
 
@@ -17,7 +17,7 @@ describe('BigpayClient', () => {
 
     describe('construct', () => {
         it('should set host', () => {
-            bigpayClient = new BigpayClient(config);
+            bigpayClient = new Client(config);
 
             expect(bigpayClient.host).toEqual(config.host);
         });
@@ -27,7 +27,7 @@ describe('BigpayClient', () => {
         let data;
 
         beforeEach(() => {
-            bigpayClient = new BigpayClient(config);
+            bigpayClient = new Client(config);
             data = cloneDeep(paymentRequestDataMock);
             data.paymentMethod.type = HOSTED;
         });
@@ -45,7 +45,7 @@ describe('BigpayClient', () => {
         let data;
 
         beforeEach(() => {
-            bigpayClient = new BigpayClient(config);
+            bigpayClient = new Client(config);
             data = paymentRequestDataMock;
         });
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,13 +5,13 @@ function getWebpackConfig() {
         context: __dirname,
         devtool: 'source-map',
         entry: {
-            'bigpay-client': './src/bigpay-client.js',
-            'bigpay-client.min': './src/bigpay-client.js',
+            'bigpay-client': './src/index.js',
+            'bigpay-client.min': './src/index.js',
         },
         output: {
             filename: '[name].js',
             path: './dist',
-            library: 'BigpayClient',
+            library: 'bigpayClient',
             libraryTarget: 'umd',
         },
         module: {


### PR DESCRIPTION
## What?
- Export a module instead of a class constructor. Instead of calling `new BigpayClient()`, you can call `bigpayClient.createClient()`.
- Set `index.js` as the main entry point for this library.
## Why?
- Firstly, I want to get around this issue. When this library gets consumed directly using a `script` tag, you have to do this:

``` js
new BigpayClient.default();
```

This is because of the way ES6 export works (for more info: https://github.com/babel/babel/issues/2212).
- Secondly, it's limiting if I only export a constructor instead of exporting a module. When I export a module, I can export more than one thing (a collection of functions, classes or sub-modules).
## Testing / Proof
- Unit

@bigcommerce-labs/checkout @wedy @bc-marquis-ong 
