### PR TITLE
CHECKOUT-973: Use node-style callback instead of promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,15 @@ const client = createClient({
     host: 'https://payments.bigcommerce.com',
 });
 
-client.submitPayment(getPaymentData());
+const data = getPaymentData();
+
+client.submitPayment(data, (error, response) => {
+    if (error) {
+        throw error;
+    }
+
+    console.log(response);
+});
 ```
 
 In `payment.js`
@@ -41,26 +49,26 @@ export default function getPaymentData() {
                 integerAmount: 12000,
             },
             handling: {
-                amount: 0,
+                integerAmount: 0,
             },
             id: '123',
             items: [
                 {
-                    amount: 10000,
                     id: '123',
+                    integerAmount: 10000,
                     name: 'Cheese',
                     quantity: 1,
                     sku: '123456789',
                 },
             ],
             shipping: {
-                amount: 1000,
+                integerAmount: 1000,
             },
             subTotal: {
-                amount: 10000,
+                integerAmount: 10000,
             },
             taxTotal: {
-                amount: 1000,
+                integerAmount: 1000,
             },
         },
         customer: {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,7 +13,6 @@ function configureKarma(config) {
         ],
         files: [
             './node_modules/jasmine-ajax/lib/mock-ajax.js',
-            './node_modules/es6-promise/dist/es6-promise.js',
             './test/index.js',
         ],
         frameworks: [

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "babel-core": "6.14.0",
     "babel-loader": "6.2.5",
     "babel-preset-es2015": "6.14.0",
-    "es6-promise": "3.2.1",
     "eslint": "3.4.0",
     "eslint-config-airbnb-base": "7.0.0",
     "eslint-loader": "1.5.0",

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -13,30 +13,34 @@ export default class Client {
     /**
      * Initialize offsite payment
      * @param {PaymentRequestData} data
-     * @returns {Promise}
+     * @param {Function} [callback]
+     * @returns {void}
      */
-    initializeOffsitePayment(data) {
+    initializeOffsitePayment(data, callback) {
         const { paymentMethod = {} } = data;
+        const options = { host: this.host };
 
         if (paymentMethod.type !== PAYMENT_TYPES.HOSTED) {
             throw new Error(`${data.type} is not supported.`);
         }
 
-        return initializeOffsitePayment(data, { host: this.host });
+        initializeOffsitePayment(data, options, callback);
     }
 
     /**
      * Submit payment
      * @param {PaymentRequestData} data
-     * @returns {Promise}
+     * @param {Function} [callback]
+     * @returns {void}
      */
-    submitPayment(data) {
+    submitPayment(data, callback) {
         const { paymentMethod = {} } = data;
+        const options = { host: this.host };
 
         if (paymentMethod.type !== PAYMENT_TYPES.API) {
             throw new Error(`${data.type} is not supported.`);
         }
 
-        return submitPayment(data, { host: this.host });
+        submitPayment(data, options, callback);
     }
 }

--- a/src/common/form-request/post-form.js
+++ b/src/common/form-request/post-form.js
@@ -4,18 +4,17 @@ import createForm from './create-form';
  * Post form
  * @param {string} url
  * @param {Object} data
- * @returns {Promise}
+ * @param {Function} [callback]
+ * @returns {void}
  */
-export default function postForm(url, data) {
+export default function postForm(url, data, callback = () => {}) {
     const form = createForm(url, data);
 
     form.submit();
 
-    return new Promise(resolve => {
-        window.addEventListener('beforeunload', function handleBeforeUnload() {
-            window.removeEventListener('beforeunload', handleBeforeUnload);
+    window.addEventListener('beforeunload', function handleBeforeUnload() {
+        window.removeEventListener('beforeunload', handleBeforeUnload);
 
-            resolve();
-        });
+        callback();
     });
 }

--- a/src/common/http-request/create-request.js
+++ b/src/common/http-request/create-request.js
@@ -34,21 +34,14 @@ function setOptions(xhr, options) {
  * Create XMLHttpRequest
  * @param {string} url
  * @param {Object} options
- * @param {Object} [callbacks]
- * @param {Function} [callbacks.onload]
- * @param {Function} [callbacks.onerror]
+ * @param {Function} [callback]
  * @returns {XMLHttpRequest}
  */
-export default function createRequest(url, options, { onload, onerror } = {}) {
+export default function createRequest(url, options, callback = () => {}) {
     const xhr = new XMLHttpRequest();
 
-    if (onerror) {
-        xhr.onerror = () => onerror(xhr);
-    }
-
-    if (onload) {
-        xhr.onload = () => onload(xhr);
-    }
+    xhr.onerror = () => callback(new Error(xhr.statusText));
+    xhr.onload = () => callback();
 
     xhr.open(options.method, url, true);
     setOptions(xhr, options);

--- a/src/common/http-request/post-request.js
+++ b/src/common/http-request/post-request.js
@@ -7,12 +7,13 @@ import sendRequest from './send-request';
  * @param {string} url
  * @param {Object} data
  * @param {Object} [options]
- * @returns {Promise}
+ * @param {Function} [callback]
+ * @returns {void}
  */
-export default function postRequest(url, data, options) {
+export default function postRequest(url, data, options, callback) {
     const mergedOptions = objectAssign({}, options, {
         method: METHOD_TYPES.POST,
     });
 
-    return sendRequest(url, data, mergedOptions);
+    sendRequest(url, data, mergedOptions, callback);
 }

--- a/src/common/http-request/send-request.js
+++ b/src/common/http-request/send-request.js
@@ -52,27 +52,25 @@ function isSuccessfulRequest(xhr) {
  * @param {string} url
  * @param {Object} data
  * @param {Object} [options]
- * @returns {Promise}
+ * @param {Function} [callback]
+ * @returns {void}
  */
-export default function sendRequest(url, data, options) {
+export default function sendRequest(url, data, options, callback = () => {}) {
     const mergedOptions = deepAssign({}, DEFAULT_OPTIONS, options);
 
-    return new Promise((resolve, reject) => {
-        function onerror(xhr) {
-            reject(getResponse(xhr));
+    const xhr = createRequest(url, mergedOptions, error => {
+        const response = getResponse(xhr);
+
+        if (error || !isSuccessfulRequest(xhr)) {
+            callback(response);
+
+            return;
         }
 
-        function onload(xhr) {
-            if (isSuccessfulRequest(xhr)) {
-                resolve(getResponse(xhr));
-            } else {
-                onerror(xhr);
-            }
-        }
-
-        const xhr = createRequest(url, mergedOptions, { onerror, onload });
-        const payload = getRequestBody(data, mergedOptions.headers['Content-Type']);
-
-        xhr.send(payload);
+        callback(null, response);
     });
+
+    const payload = getRequestBody(data, mergedOptions.headers['Content-Type']);
+
+    xhr.send(payload);
 }

--- a/src/payment/initialize-offsite-payment.js
+++ b/src/payment/initialize-offsite-payment.js
@@ -7,11 +7,12 @@ import { postForm } from '../common/form-request';
  * @param {PaymentRequestData} data
  * @param {Object} [options = {}]
  * @param {string} [options.host]
- * @returns {Promise}
+ * @param {Function} [callback]
+ * @returns {void}
  */
-export default function initializeOffsitePayment(data, { host } = {}) {
+export default function initializeOffsitePayment(data, { host } = {}, callback) {
     const payload = mapToPayload(data);
     const url = getOffsitePaymentUrl(host);
 
-    return postForm(url, payload);
+    postForm(url, payload, callback);
 }

--- a/src/payment/submit-payment.js
+++ b/src/payment/submit-payment.js
@@ -7,14 +7,15 @@ import { mapToHeaders, mapToPayload } from './mappers';
  * @param {PaymentRequestData} data
  * @param {Object} [options = {}]
  * @param {string} [options.host]
- * @returns {Promise}
+ * @param {Function} [callback]
+ * @returns {void}
  */
-export default function submitPayment(data, { host } = {}) {
+export default function submitPayment(data, { host } = {}, callback) {
     const payload = mapToPayload(data);
     const url = getPaymentUrl(host);
     const options = {
         headers: mapToHeaders(data),
     };
 
-    return postRequest(url, payload, options);
+    postRequest(url, payload, options, callback);
 }

--- a/test/client/client.spec.js
+++ b/test/client/client.spec.js
@@ -5,10 +5,12 @@ import Client from '../../src/client/client';
 import paymentRequestDataMock from '../mocks/payment-request-data';
 
 describe('Client', () => {
-    let bigpayClient;
+    let callback;
+    let client;
     let config;
 
     beforeEach(() => {
+        callback = () => {};
         config = { host: 'https://bcapp.dev' };
 
         spyOn(paymentModule, 'initializeOffsitePayment');
@@ -17,9 +19,9 @@ describe('Client', () => {
 
     describe('construct', () => {
         it('should set host', () => {
-            bigpayClient = new Client(config);
+            client = new Client(config);
 
-            expect(bigpayClient.host).toEqual(config.host);
+            expect(client.host).toEqual(config.host);
         });
     });
 
@@ -27,7 +29,7 @@ describe('Client', () => {
         let data;
 
         beforeEach(() => {
-            bigpayClient = new Client(config);
+            client = new Client(config);
             data = cloneDeep(paymentRequestDataMock);
             data.paymentMethod.type = HOSTED;
         });
@@ -35,9 +37,9 @@ describe('Client', () => {
         it('should initialize offsite payment', () => {
             const { initializeOffsitePayment } = paymentModule;
 
-            bigpayClient.initializeOffsitePayment(data);
+            client.initializeOffsitePayment(data, callback);
 
-            expect(initializeOffsitePayment).toHaveBeenCalledWith(data, { host: config.host });
+            expect(initializeOffsitePayment).toHaveBeenCalledWith(data, { host: config.host }, callback);
         });
     });
 
@@ -45,16 +47,16 @@ describe('Client', () => {
         let data;
 
         beforeEach(() => {
-            bigpayClient = new Client(config);
+            client = new Client(config);
             data = paymentRequestDataMock;
         });
 
         it('should submit payment', () => {
             const { submitPayment } = paymentModule;
 
-            bigpayClient.submitPayment(data);
+            client.submitPayment(data, callback);
 
-            expect(submitPayment).toHaveBeenCalledWith(data, { host: config.host });
+            expect(submitPayment).toHaveBeenCalledWith(data, { host: config.host }, callback);
         });
     });
 });

--- a/test/common/http-request/post-request.spec.js
+++ b/test/common/http-request/post-request.spec.js
@@ -2,11 +2,13 @@ import postRequest from '../../../src/common/http-request/post-request';
 import * as sendRequestModule from '../../../src/common/http-request/send-request';
 
 describe('postRequest', () => {
+    let callback;
     let data;
     let options;
     let url;
 
     beforeEach(() => {
+        callback = () => {};
         data = { body: 'hello world' };
         options = {};
         url = '/endpoint';
@@ -17,8 +19,8 @@ describe('postRequest', () => {
     it('should post XHR', () => {
         const sendRequest = sendRequestModule.default;
 
-        postRequest(url, data, options);
+        postRequest(url, data, options, callback);
 
-        expect(sendRequest).toHaveBeenCalledWith('/endpoint', data, { method: 'POST' });
+        expect(sendRequest).toHaveBeenCalledWith('/endpoint', data, { method: 'POST' }, callback);
     });
 });

--- a/test/common/http-request/send-request.spec.js
+++ b/test/common/http-request/send-request.spec.js
@@ -23,11 +23,6 @@ describe('sendRequest', () => {
     it('should create XHR', () => {
         const { default: createRequest } = createRequestModule;
 
-        const callbacks = {
-            onerror: jasmine.any(Function),
-            onload: jasmine.any(Function),
-        };
-
         const expectedOptions = {
             headers: {
                 Accept: 'application/json',
@@ -38,7 +33,7 @@ describe('sendRequest', () => {
 
         sendRequest(url, data, options);
 
-        expect(createRequest).toHaveBeenCalledWith(url, expectedOptions, callbacks);
+        expect(createRequest).toHaveBeenCalledWith(url, expectedOptions, jasmine.any(Function));
     });
 
     it('should send XHR with payload', () => {
@@ -51,12 +46,11 @@ describe('sendRequest', () => {
         expect(request.data()).toEqual(data);
     });
 
-    it('should resolve promise if successful', done => {
-        sendRequest(url, data, options)
-            .then(resp => {
-                expect(resp).toBeDefined();
-                done();
-            });
+    it('should return response in callback if successful', done => {
+        sendRequest(url, data, options, (err, resp) => {
+            expect(resp).toBeDefined();
+            done();
+        });
 
         const request = jasmine.Ajax.requests.mostRecent();
 
@@ -66,12 +60,11 @@ describe('sendRequest', () => {
         });
     });
 
-    it('should reject promise if unsuccessful', done => {
-        sendRequest(url, data, options)
-            .catch(err => {
-                expect(err).toBeDefined();
-                done();
-            });
+    it('should return error in callback if unsuccessful', done => {
+        sendRequest(url, data, options, err => {
+            expect(err).toBeDefined();
+            done();
+        });
 
         const request = jasmine.Ajax.requests.mostRecent();
 
@@ -79,15 +72,15 @@ describe('sendRequest', () => {
     });
 
     it('should parse response body as JSON if content type is JSON', done => {
-        sendRequest(url, data, options)
-            .then(resp => {
-                expect(resp).toEqual({
-                    data: { message: 'foobar' },
-                    status: 200,
-                    statusText: 'OK',
-                });
-                done();
+        sendRequest(url, data, options, (err, resp) => {
+            expect(resp).toEqual({
+                data: { message: 'foobar' },
+                status: 200,
+                statusText: 'OK',
             });
+
+            done();
+        });
 
         const request = jasmine.Ajax.requests.mostRecent();
 

--- a/test/payment/initialilze-offsite-payment.spec.js
+++ b/test/payment/initialilze-offsite-payment.spec.js
@@ -5,18 +5,18 @@ import paymentRequestDataMock from '../mocks/payment-request-data';
 import initializeOffsitePayment from '../../src/payment/initialize-offsite-payment';
 
 describe('initializeOffsitePayment', () => {
+    let callback;
     let data;
     let options;
-    let promise;
     let transformedData;
 
     beforeEach(() => {
+        callback = () => {};
         data = paymentRequestDataMock;
         transformedData = { body: 'hello world' };
         options = { host: 'https://bcapp.dev' };
-        promise = Promise.resolve({ ok: true });
 
-        spyOn(formRequestModule, 'postForm').and.returnValue(promise);
+        spyOn(formRequestModule, 'postForm');
         spyOn(offsiteMappersModule, 'mapToPayload').and.returnValue(transformedData);
         spyOn(urlsModule, 'getOffsitePaymentUrl').and.returnValue(`${options.host}/api/pay/initialize`);
     });
@@ -24,7 +24,7 @@ describe('initializeOffsitePayment', () => {
     it('should transform input data', () => {
         const { mapToPayload } = offsiteMappersModule;
 
-        initializeOffsitePayment(data, options);
+        initializeOffsitePayment(data, options, callback);
 
         expect(mapToPayload).toHaveBeenCalled();
     });
@@ -32,8 +32,8 @@ describe('initializeOffsitePayment', () => {
     it('should post request data to server', () => {
         const url = urlsModule.getOffsitePaymentUrl();
 
-        initializeOffsitePayment(data, options);
+        initializeOffsitePayment(data, options, callback);
 
-        expect(formRequestModule.postForm).toHaveBeenCalledWith(url, transformedData);
+        expect(formRequestModule.postForm).toHaveBeenCalledWith(url, transformedData, callback);
     });
 });

--- a/test/payment/submit-payment.spec.js
+++ b/test/payment/submit-payment.spec.js
@@ -5,20 +5,20 @@ import paymentRequestDataMock from '../mocks/payment-request-data';
 import submitPayment from '../../src/payment/submit-payment';
 
 describe('submitPayment', () => {
+    let callback;
     let data;
     let headers;
     let options;
-    let promise;
     let transformedData;
 
     beforeEach(() => {
+        callback = () => {};
         data = paymentRequestDataMock;
         transformedData = { body: 'hello world' };
         headers = { AUTH_TOKEN: '123' };
         options = { host: 'https://bcapp.dev' };
-        promise = Promise.resolve({ ok: true });
 
-        spyOn(httpRequestModule, 'postRequest').and.returnValue(promise);
+        spyOn(httpRequestModule, 'postRequest');
         spyOn(mappersModule, 'mapToHeaders').and.returnValue(headers);
         spyOn(mappersModule, 'mapToPayload').and.returnValue(transformedData);
         spyOn(urlsModule, 'getPaymentUrl').and.returnValue(`${options.host}/api/public/v1/payments/payment`);
@@ -27,7 +27,7 @@ describe('submitPayment', () => {
     it('should transform input data', () => {
         const { mapToPayload } = mappersModule;
 
-        submitPayment(data, options);
+        submitPayment(data, options, callback);
 
         expect(mapToPayload).toHaveBeenCalled();
     });
@@ -35,8 +35,8 @@ describe('submitPayment', () => {
     it('should post payment data to server', () => {
         const url = urlsModule.getPaymentUrl();
 
-        submitPayment(data, options);
+        submitPayment(data, options, callback);
 
-        expect(httpRequestModule.postRequest).toHaveBeenCalledWith(url, transformedData, { headers });
+        expect(httpRequestModule.postRequest).toHaveBeenCalledWith(url, transformedData, { headers }, callback);
     });
 });


### PR DESCRIPTION
## What?
- Use node-style callback instead of promises.
## Why?
- `Promise` is not supported in IE8-11 (http://caniuse.com/#search=promise). In order to use it, we need a polyfill. There's no practical reason why it needs to use `Promise` anyway, because:
  - This library doesn't fire off a chain of asynchronous calls.
  - The consuming app might be using a different promise library. For example, UCO uses `$q`, which has a slightly different interface to `Promise`.
- Use node-style callback (error first), instead of `onError` and `onSuccess` callbacks, because it is a more well-known convention. For example, `braintree-web` uses node-style callbacks.
## Testing / Proof
- Unit tests

@bigcommerce-labs/checkout @wedy @bc-marquis-ong 
