### PR TITLE
CHECKOUT-1175: Use grandTotal from order object instead of cart

### DIFF
--- a/src/payment/mappers/map-to-order-totals.js
+++ b/src/payment/mappers/map-to-order-totals.js
@@ -6,13 +6,13 @@ import { omitNil } from '../../common/utils';
  * @returns {Object}
  */
 export default function mapToOrderTotals(data) {
-    const { cart } = data;
+    const { order } = data;
 
     return omitNil({
-        grand_total: cart.grandTotal ? cart.grandTotal.integerAmount : null,
-        handling: cart.handling ? cart.handling.integerAmount : null,
-        shipping: cart.shipping ? cart.shipping.integerAmount : null,
-        subtotal: cart.subTotal ? cart.subTotal.integerAmount : null,
-        tax: cart.taxTotal ? cart.taxTotal.integerAmount : null,
+        grand_total: order.grandTotal ? order.grandTotal.integerAmount : null,
+        handling: order.handling ? order.handling.integerAmount : null,
+        shipping: order.shipping ? order.shipping.integerAmount : null,
+        subtotal: order.subTotal ? order.subTotal.integerAmount : null,
+        tax: order.taxTotal ? order.taxTotal.integerAmount : null,
     });
 }

--- a/src/payment/mappers/map-to-order.js
+++ b/src/payment/mappers/map-to-order.js
@@ -10,11 +10,11 @@ import mapToShippingAddress from './map-to-shipping-address';
  * @returns {Object}
  */
 export default function mapToOrder(data) {
-    const { cart, order } = data;
+    const { order } = data;
 
     return omitNil({
         billing_address: mapToBillingAddress(data),
-        currency: cart.currency,
+        currency: order.currency,
         id: toString(order.orderId),
         items: mapToItems(data),
         shipping_address: mapToShippingAddress(data),

--- a/src/payment/offsite-mappers/map-to-payload.js
+++ b/src/payment/offsite-mappers/map-to-payload.js
@@ -12,13 +12,13 @@ import mapToStore from './map-to-store';
  * @returns {Object}
  */
 export default function mapToPayload(data) {
-    const { authToken, cart = {}, order = {}, paymentMethod = {} } = data;
+    const { authToken, order = {}, paymentMethod = {} } = data;
 
     const payload = objectAssign(
         {
-            amount: cart.grandTotal ? cart.grandTotal.integerAmount : null,
+            amount: order.grandTotal ? order.grandTotal.integerAmount : null,
             bc_auth_token: authToken,
-            currency: cart.currency,
+            currency: order.currency,
             gateway: paymentMethod.gateway,
             notify_url: order.callbackUrl,
             order_id: toString(order.orderId),

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -29,18 +29,7 @@
 
 /**
  * @typedef {Object} CartData
- * @property {string} currency
- * @property {Object} grandTotal
- * @property {number} grandTotal.integerAmount
- * @property {Object} [handling]
- * @property {number} [handling.integerAmount]
  * @property {ItemData[]} [items]
- * @property {Object} [shipping]
- * @property {number} [shipping.integerAmount]
- * @property {Object} [subTotal]
- * @property {number} [subTotal.integerAmount]
- * @property {Object} [taxTotal]
- * @property {number} [taxTotal.integerAmount]
  */
 
 /**
@@ -63,10 +52,21 @@
 
 /**
  * @typedef {Object} OrderData
+ * @property {string} currency
  * @property {string} orderId
+ * @property {Object} grandTotal
+ * @property {number} grandTotal.integerAmount
+ * @property {string} [callbackUrl]
+ * @property {Object} [handling]
+ * @property {number} [handling.integerAmount]
  * @property {Object} [payment]
  * @property {string} [payment.returnUrl]
- * @property {string} [callbackUrl]
+ * @property {Object} [shipping]
+ * @property {number} [shipping.integerAmount]
+ * @property {Object} [subTotal]
+ * @property {number} [subTotal.integerAmount]
+ * @property {Object} [taxTotal]
+ * @property {number} [taxTotal.integerAmount]
  * @property {string} [token]
  */
 

--- a/test/mocks/payment-request-data.js
+++ b/test/mocks/payment-request-data.js
@@ -17,14 +17,6 @@ const paymentRequestDataMock = {
         province: 'New South Wales',
     },
     cart: {
-        currency: 'AUD',
-        grandTotal: {
-            integerAmount: 12000,
-        },
-        handling: {
-            integerAmount: 500,
-        },
-        id: '123',
         items: [
             {
                 integerAmount: 10000,
@@ -34,15 +26,6 @@ const paymentRequestDataMock = {
                 sku: '123456789',
             },
         ],
-        shipping: {
-            integerAmount: 1000,
-        },
-        subTotal: {
-            integerAmount: 10000,
-        },
-        taxTotal: {
-            integerAmount: 1000,
-        },
     },
     customer: {
         customerId: '123',
@@ -56,9 +39,25 @@ const paymentRequestDataMock = {
     },
     order: {
         callbackUrl: '/order/123/payment',
+        currency: 'AUD',
+        grandTotal: {
+            integerAmount: 12000,
+        },
+        handling: {
+            integerAmount: 500,
+        },
         orderId: '123',
         payment: {
             returnUrl: '/checkout',
+        },
+        shipping: {
+            integerAmount: 1000,
+        },
+        subTotal: {
+            integerAmount: 10000,
+        },
+        taxTotal: {
+            integerAmount: 1000,
         },
         token: 'abc123',
     },

--- a/test/payment/mappers/map-to-order-totals.spec.js
+++ b/test/payment/mappers/map-to-order-totals.spec.js
@@ -12,11 +12,11 @@ describe('mapToOrderTotals', () => {
         const output = mapToOrderTotals(data);
 
         expect(output).toEqual({
-            grand_total: data.cart.grandTotal.integerAmount,
-            handling: data.cart.handling.integerAmount,
-            shipping: data.cart.shipping.integerAmount,
-            subtotal: data.cart.subTotal.integerAmount,
-            tax: data.cart.taxTotal.integerAmount,
+            grand_total: data.order.grandTotal.integerAmount,
+            handling: data.order.handling.integerAmount,
+            shipping: data.order.shipping.integerAmount,
+            subtotal: data.order.subTotal.integerAmount,
+            tax: data.order.taxTotal.integerAmount,
         });
     });
 });

--- a/test/payment/mappers/map-to-order.spec.js
+++ b/test/payment/mappers/map-to-order.spec.js
@@ -22,7 +22,7 @@ describe('mapToOrder', () => {
 
         expect(output).toEqual({
             billing_address: 'billingAddress',
-            currency: data.cart.currency,
+            currency: data.order.currency,
             id: `${data.order.orderId}`,
             items: 'items',
             shipping_address: 'shippingAddress',

--- a/test/payment/offsite-mappers/map-to-payload.spec.js
+++ b/test/payment/offsite-mappers/map-to-payload.spec.js
@@ -30,10 +30,10 @@ describe('mapToPayload', () => {
         const output = mapToPayload(data);
 
         expect(output).toEqual({
-            amount: data.cart.grandTotal.integerAmount,
+            amount: data.order.grandTotal.integerAmount,
             bc_auth_token: data.authToken,
             billingAddress: 'billingAddress',
-            currency: data.cart.currency,
+            currency: data.order.currency,
             customer: 'customer',
             gateway: data.paymentMethod.gateway,
             meta: 'meta',


### PR DESCRIPTION
## What?
- Use `grandTotal`, `handling`, `shipping`, `subTotal`, `taxTotal` and `currency` from `order` object instead of `cart` object.
## Why?
- The grand total of an order will change after applying store credits. Therefore, it is different from the amount you get when the cart is initially loaded.
## Testing / Proof
- Manual

@bigcommerce-labs/checkout @wedy @bc-marquis-ong 
