### PR TITLE
BIG-28886: Fix geo ip field name

### DIFF
--- a/src/payment/offsite-mappers/map-to-customer.js
+++ b/src/payment/offsite-mappers/map-to-customer.js
@@ -12,7 +12,7 @@ export default function mapToCustomer(data) {
         customer_browser_info: navigator.userAgent,
         customer_email: customer.email,
         customer_first_name: customer.firstName,
-        customer_geo_country_code: customer.geoCountryCode,
+        customer_geo_ip_country_code: customer.geoCountryCode,
         customer_last_name: customer.lastName,
         customer_locale: store.storeLanguage,
         customer_name: customer.name,

--- a/test/payment/offsite-mappers/map-to-customer.spec.js
+++ b/test/payment/offsite-mappers/map-to-customer.spec.js
@@ -15,7 +15,7 @@ describe('mapToCustomer', () => {
             customer_browser_info: navigator.userAgent,
             customer_email: data.customer.email,
             customer_first_name: data.customer.firstName,
-            customer_geo_country_code: data.customer.geoCountryCode,
+            customer_geo_ip_country_code: data.customer.geoCountryCode,
             customer_last_name: data.customer.lastName,
             customer_locale: data.store.storeLanguage,
             customer_name: data.customer.name,


### PR DESCRIPTION
## What?
- `customer_geo_ip_country_code` instead of `customer_geo_country_code`
## Why?
- Wrong field name
## Testing / Proof
- Manual

@bigcommerce-labs/payments 
