### PR TITLE
BIG-28950: Fix hidden form submission issue in Firefox

### DIFF
--- a/src/common/form-request/create-form.js
+++ b/src/common/form-request/create-form.js
@@ -8,6 +8,7 @@ function createInput(value, key) {
     const input = document.createElement('input');
 
     input.setAttribute('name', key);
+    input.setAttribute('type', 'hidden');
     input.setAttribute('value', value);
 
     return input;
@@ -21,6 +22,8 @@ function createInput(value, key) {
  */
 export default function createForm(url, data) {
     const form = document.createElement('form');
+
+    form.style.display = 'none';
 
     form.setAttribute('action', url);
     form.setAttribute('method', 'POST');

--- a/src/common/form-request/post-form.js
+++ b/src/common/form-request/post-form.js
@@ -10,7 +10,10 @@ import createForm from './create-form';
 export default function postForm(url, data, callback = () => {}) {
     const form = createForm(url, data);
 
+    // Some browsers require the form to be part of DOM in order to submit
+    document.body.appendChild(form);
     form.submit();
+    document.body.removeChild(form);
 
     window.addEventListener('beforeunload', function handleBeforeUnload() {
         window.removeEventListener('beforeunload', handleBeforeUnload);

--- a/test/common/form-request/create-form.spec.js
+++ b/test/common/form-request/create-form.spec.js
@@ -16,9 +16,9 @@ describe('createForm', () => {
         const output = createForm(actionUrl, fields);
 
         expect(output.outerHTML).toEqual(
-            '<form action="/pay/initialize" method="POST" target="_top">' +
-                '<input name="field_1" value="foo">' +
-                '<input name="field_2" value="bar">' +
+            '<form action="/pay/initialize" method="POST" target="_top" style="display: none;">' +
+                '<input name="field_1" type="hidden" value="foo">' +
+                '<input name="field_2" type="hidden" value="bar">' +
             '</form>'
         );
     });

--- a/test/common/form-request/post-form.spec.js
+++ b/test/common/form-request/post-form.spec.js
@@ -9,9 +9,10 @@ describe('postForm', () => {
     beforeEach(() => {
         actionUrl = '/pay/initialize';
         data = { id: 'adyen' };
-        form = jasmine.createSpyObj('form', ['submit']);
+        form = document.createElement('form');
 
         spyOn(createFormModule, 'default').and.returnValue(form);
+        spyOn(form, 'submit');
     });
 
     it('should create form', () => {


### PR DESCRIPTION
## What?
- Add `form` to the DOM before calling `submit`.
## Why?
- In Firefox you can't call `form.submit` unless the form is added to DOM.
## Testing / Proof

<img width="1012" alt="screen shot 2016-10-28 at 4 18 06 pm" src="https://cloud.githubusercontent.com/assets/667603/19795732/265f5778-9d2a-11e6-92d0-13912e651f0a.png">

@bigcommerce-labs/payments @icatalina 
