### PR TITLE
CHECKOUT-1127: Update nonce and device info mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,8 @@ export default function getPaymentData() {
         customer: {
             customerId: '123',
             firstName: 'Foo',
-            geoCountryCode: 'AU',
             lastName: 'Bar',
             locale: 'en-AU',
-            sessionHash: 'abc123',
         },
         order: {
             currency: 'AUD',
@@ -92,11 +90,15 @@ export default function getPaymentData() {
             ccNumber: '4007000000027',
         },
         paymentMethod: {
-            config: {
-                redirectUrl: '/checkout',
-            },
             id: 'paypalprous',
             type: 'PAYMENT_TYPE_API',
+        },
+        quoteMeta: {
+            request: {
+                deviceSessionId: 'xyz123',
+                geoCountryCode: 'AU',
+                sessionHash: 'abc123',
+            },
         },
         shippingAddress: {
             addressLine1: '685 Market St',
@@ -115,8 +117,9 @@ export default function getPaymentData() {
         source: 'bcapp-checkout-uco',
         store: {
             storeHash: 's123456789',
-            storeName: 'Test Store',
             storeId: '100',
+            storeLanguage: 'en-AU',
+            storeName: 'Test Store',
         },
     }
 }

--- a/src/payment/mappers/map-to-customer.js
+++ b/src/payment/mappers/map-to-customer.js
@@ -6,11 +6,11 @@ import { omitNil, toString } from '../../common/utils';
  * @returns {Object}
  */
 export default function mapToCustomer(data) {
-    const { customer = {} } = data;
+    const { customer = {}, quoteMeta = {} } = data;
 
     return omitNil({
-        geo_ip_country_code: customer.geoCountryCode,
+        geo_ip_country_code: quoteMeta.request ? quoteMeta.request.geoCountryCode : null,
         id: toString(customer.customerId),
-        session_token: customer.sessionHash,
+        session_token: quoteMeta.request ? quoteMeta.request.sessionHash : null,
     });
 }

--- a/src/payment/mappers/map-to-payment.js
+++ b/src/payment/mappers/map-to-payment.js
@@ -8,18 +8,18 @@ import mapToCreditCard from './map-to-credit-card';
  * @returns {Object}
  */
 export default function mapToPayment(data) {
-    const { order = {}, payment = {}, paymentMethod = {} } = data;
+    const { order = {}, paymentMethod = {}, quoteMeta = {} } = data;
 
     const payload = {
-        device_info: payment.deviceData,
+        device_info: quoteMeta.request ? quoteMeta.request.deviceSessionId : null,
         gateway: paymentMethod.id,
         notify_url: order.callbackUrl,
     };
 
-    if (payment.nonce) {
+    if (paymentMethod.nonce) {
         objectAssign(payload, {
             credit_card_token: {
-                token: payment.nonce,
+                token: paymentMethod.nonce,
             },
         });
     } else {

--- a/src/payment/offsite-mappers/map-to-customer.js
+++ b/src/payment/offsite-mappers/map-to-customer.js
@@ -6,13 +6,13 @@ import { omitNil } from '../../common/utils';
  * @returns {Object}
  */
 export default function mapToCustomer(data) {
-    const { customer = {}, store = {} } = data;
+    const { customer = {}, quoteMeta = {}, store = {} } = data;
 
     return omitNil({
         customer_browser_info: navigator.userAgent,
         customer_email: customer.email,
         customer_first_name: customer.firstName,
-        customer_geo_ip_country_code: customer.geoCountryCode,
+        customer_geo_ip_country_code: quoteMeta.request ? quoteMeta.request.geoCountryCode : null,
         customer_last_name: customer.lastName,
         customer_locale: store.storeLanguage,
         customer_name: customer.name,

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -1,73 +1,72 @@
 /**
  * @typedef {Object} PaymentRequestData
  * @property {string} authToken
+ * @property {AddressData} billingAddress
  * @property {CartData} cart
+ * @property {CustomerData} customer
  * @property {OrderData} order
+ * @property {PaymentData} payment
  * @property {PaymentMethodData} paymentMethod
+ * @property {QuoteMetaData} quoteMeta
+ * @property {AddressData} shippingAddress
  * @property {StoreData} store
- * @property {AddressData} [billingAddress]
- * @property {CustomerData} [customer]
- * @property {PaymentData|NoucePaymentData} payment
- * @property {AddressData} [shippingAddress]
  */
 
 /**
  * @typedef {Object} AddressData
- * @property {string} [addressLine1]
- * @property {string} [addressLine2]
- * @property {string} [city]
- * @property {string} [company]
- * @property {string} [country]
- * @property {string} [countryCode]
- * @property {string} [firstName]
- * @property {string} [lastName]
- * @property {string} [phone]
- * @property {string} [postCode]
- * @property {string} [province]
- * @property {string} [provinceCode]
+ * @property {string} addressLine1
+ * @property {string} addressLine2
+ * @property {string} city
+ * @property {string} company
+ * @property {string} country
+ * @property {string} countryCode
+ * @property {string} firstName
+ * @property {string} lastName
+ * @property {string} phone
+ * @property {string} postCode
+ * @property {string} province
+ * @property {string} provinceCode
  */
 
 /**
  * @typedef {Object} CartData
- * @property {ItemData[]} [items]
+ * @property {ItemData[]} items
  */
 
 /**
  * @typedef {Object} CustomerData
- * @property {string} [customerId]
- * @property {string} [firstName]
- * @property {string} [geoCountryCode]
- * @property {string} [lastName]
- * @property {string} [sessionHash]
+ * @property {string} customerId
+ * @property {string} firstName
+ * @property {string} lastName
  */
 
 /**
  * @typedef {Object} ItemData
- * @property {number} [integerAmount]
- * @property {number} [quantity]
- * @property {string} [id]
- * @property {string} [name]
- * @property {string} [sku]
+ * @property {string} id
+ * @property {number} integerAmount
+ * @property {string} name
+ * @property {number} quantity
+ * @property {string} sku
  */
 
 /**
  * @typedef {Object} OrderData
- * @property {string} currency
- * @property {string} orderId
  * @property {Object} grandTotal
  * @property {number} grandTotal.integerAmount
+ * @property {Object} handling
+ * @property {number} handling.integerAmount
+ * @property {Object} shipping
+ * @property {number} shipping.integerAmount
+ * @property {Object} subtotal
+ * @property {number} subtotal.integerAmount
+ * @property {Object} taxTotal
+ * @property {string} currency
+ * @property {string} orderId
+ * @property {number} taxTotal.integerAmount
+ * @property {string} token
  * @property {string} [callbackUrl]
- * @property {Object} [handling]
- * @property {number} [handling.integerAmount]
  * @property {Object} [payment]
  * @property {string} [payment.returnUrl]
- * @property {Object} [shipping]
- * @property {number} [shipping.integerAmount]
- * @property {Object} [subtotal]
- * @property {number} [subtotal.integerAmount]
- * @property {Object} [taxTotal]
- * @property {number} [taxTotal.integerAmount]
- * @property {string} [token]
  */
 
 /**
@@ -78,25 +77,28 @@
  * @property {number} ccExpiry.year
  * @property {string} ccName
  * @property {string} ccNumber
- * @property {string} [deviceData]
- */
-
-/**
- * @typedef {Object} NoucePaymentData
- * @property {string} nonce
- * @property {string} [deviceData]
  */
 
 /**
  * @typedef {Object} PaymentMethodData
  * @property {string} id
+ * @property {string} type
  * @property {string} [gateway]
+ * @property {string} [nonce]
+ */
+
+/**
+ * @typedef {Object} QuoteMetaData
+ * @property {Object} request
+ * @property {string} request.deviceSessionId
+ * @property {string} request.geoCountryCode
+ * @property {string} request.sessionHash
  */
 
 /**
  * @typedef {Object} StoreData
+ * @property {string} storeHash
  * @property {string} storeId
- * @property {string} [storeHash]
- * @property {string} [storeLanguage]
- * @property {string} [storeName]
+ * @property {string} storeLanguage
+ * @property {string} storeName
  */

--- a/test/mocks/payment-request-data.js
+++ b/test/mocks/payment-request-data.js
@@ -31,10 +31,8 @@ const paymentRequestDataMock = {
         customerId: '123',
         email: 'email@bigcommerce.com',
         firstName: 'Foo',
-        geoCountryCode: 'AU',
         lastName: 'Bar',
         name: 'Foo Bar',
-        sessionHash: 'abc123',
         phoneNumber: '98765432',
     },
     order: {
@@ -69,11 +67,17 @@ const paymentRequestDataMock = {
         },
         ccName: 'Foo Bar',
         ccNumber: '4007000000027',
-        deviceData: 'Chrome',
     },
     paymentMethod: {
         id: 'paypalprous',
         type: API,
+    },
+    quoteMeta: {
+        request: {
+            deviceSessionId: 'xyz123',
+            geoCountryCode: 'AU',
+            sessionHash: 'abc123',
+        },
     },
     shippingAddress: {
         addressLine1: '685 Market St',

--- a/test/payment/mappers/map-to-customer.spec.js
+++ b/test/payment/mappers/map-to-customer.spec.js
@@ -12,9 +12,9 @@ describe('mapToCustomer', () => {
         const output = mapToCustomer(data);
 
         expect(output).toEqual({
-            geo_ip_country_code: data.customer.geoCountryCode,
+            geo_ip_country_code: data.quoteMeta.request.geoCountryCode,
             id: `${data.customer.customerId}`,
-            session_token: data.customer.sessionHash,
+            session_token: data.quoteMeta.request.sessionHash,
         });
     });
 });

--- a/test/payment/mappers/map-to-payment.spec.js
+++ b/test/payment/mappers/map-to-payment.spec.js
@@ -17,7 +17,7 @@ describe('mapToPayment', () => {
 
         expect(output).toEqual({
             credit_card: 'creditCard',
-            device_info: data.payment.deviceData,
+            device_info: data.quoteMeta.request.deviceSessionId,
             gateway: data.paymentMethod.id,
             notify_url: data.order.callbackUrl,
         });
@@ -25,7 +25,7 @@ describe('mapToPayment', () => {
 
     it('should map to payment with credit card token data', () => {
         data = merge({}, data, {
-            payment: {
+            paymentMethod: {
                 nonce: 'abc123',
             },
         });
@@ -34,9 +34,9 @@ describe('mapToPayment', () => {
 
         expect(output).toEqual({
             credit_card_token: {
-                token: data.payment.nonce,
+                token: data.paymentMethod.nonce,
             },
-            device_info: data.payment.deviceData,
+            device_info: data.quoteMeta.request.deviceSessionId,
             gateway: data.paymentMethod.id,
             notify_url: data.order.callbackUrl,
         });

--- a/test/payment/offsite-mappers/map-to-customer.spec.js
+++ b/test/payment/offsite-mappers/map-to-customer.spec.js
@@ -15,7 +15,7 @@ describe('mapToCustomer', () => {
             customer_browser_info: navigator.userAgent,
             customer_email: data.customer.email,
             customer_first_name: data.customer.firstName,
-            customer_geo_ip_country_code: data.customer.geoCountryCode,
+            customer_geo_ip_country_code: data.quoteMeta.request.geoCountryCode,
             customer_last_name: data.customer.lastName,
             customer_locale: data.store.storeLanguage,
             customer_name: data.customer.name,


### PR DESCRIPTION
## What?
* Send `nonce`, `deviceSessionId` and `sessionHash` to BigPay if they are available.

## Why?
* Some payment providers require these attributes.

## Testing / Proof
* Manual

@bigcommerce-labs/checkout @wedy @bc-marquis-ong 

