### PR TITLE
CHECKOUT-1166: Map payment nonce and payment method id

### DIFF
--- a/src/payment-method/index.js
+++ b/src/payment-method/index.js
@@ -1,0 +1,7 @@
+import * as PAYMENT_METHODS from './payment-methods';
+import mapToId from './map-to-id';
+
+export {
+    mapToId,
+    PAYMENT_METHODS,
+};

--- a/src/payment-method/map-to-id.js
+++ b/src/payment-method/map-to-id.js
@@ -1,0 +1,14 @@
+import { BRAINTREE, BRAINTREE_PAYPAL } from './payment-methods';
+
+/**
+ * Map to gateway
+ * @param {PaymentMethod} paymentMethod
+ * @returns {string}
+ */
+export default function mapToId(paymentMethod) {
+    if (paymentMethod.id === BRAINTREE_PAYPAL) {
+        return BRAINTREE;
+    }
+
+    return paymentMethod.id;
+}

--- a/src/payment-method/payment-methods.js
+++ b/src/payment-method/payment-methods.js
@@ -1,0 +1,2 @@
+export const BRAINTREE = 'braintree';
+export const BRAINTREE_PAYPAL = 'braintreepaypal';

--- a/src/payment/mappers/map-to-payment.js
+++ b/src/payment/mappers/map-to-payment.js
@@ -1,5 +1,6 @@
 import objectAssign from 'object-assign';
 import { omitNil } from '../../common/utils';
+import { mapToId } from '../../payment-method';
 import mapToCreditCard from './map-to-credit-card';
 
 /**
@@ -12,7 +13,7 @@ export default function mapToPayment(data) {
 
     const payload = {
         device_info: quoteMeta.request ? quoteMeta.request.deviceSessionId : null,
-        gateway: paymentMethod.id,
+        gateway: mapToId(paymentMethod),
         notify_url: order.callbackUrl,
     };
 

--- a/src/payment/offsite-mappers/map-to-payload.js
+++ b/src/payment/offsite-mappers/map-to-payload.js
@@ -1,5 +1,6 @@
 import objectAssign from 'object-assign';
 import { omitNil, toString } from '../../common/utils';
+import { mapToId } from '../../payment-method';
 import mapToBillingAddress from './map-to-billing-address';
 import mapToCustomer from './map-to-customer';
 import mapToMeta from './map-to-meta';
@@ -23,7 +24,7 @@ export default function mapToPayload(data) {
             notify_url: order.callbackUrl,
             order_id: toString(order.orderId),
             page_title: document.title,
-            payment_method_id: paymentMethod.id,
+            payment_method_id: mapToId(paymentMethod),
             reference_id: toString(order.orderId),
             return_url: order.payment ? order.payment.returnUrl : null,
         },

--- a/test/payment-method/map-to-id.spec.js
+++ b/test/payment-method/map-to-id.spec.js
@@ -1,0 +1,14 @@
+import mapToId from '../../src/payment-method/map-to-id';
+import * as PAYMENT_METHODS from '../../src/payment-method/payment-methods';
+
+describe('mapToId', () => {
+    let paymentMethod;
+
+    it('should translate payment method id if neccessary', () => {
+        paymentMethod = { id: PAYMENT_METHODS.BRAINTREE_PAYPAL };
+        expect(mapToId(paymentMethod)).toEqual(PAYMENT_METHODS.BRAINTREE);
+
+        paymentMethod = { id: PAYMENT_METHODS.BRAINTREE };
+        expect(mapToId(paymentMethod)).toEqual(PAYMENT_METHODS.BRAINTREE);
+    });
+});


### PR DESCRIPTION
## What?
* Map payment nonce to the schema expected by BigPay.
* Rename `braintreepaypal` to `braintree` before sending the payload to BigPay.
* Related PR: https://github.com/bigcommerce-labs/ng-checkout/pull/344

## Why?
* To conform to BigPay schema.
* `braintreepaypal` is called `braintree` in BigPay.

## Testing / Proof
* Unit / manual

ping @bigcommerce-labs/checkout 
