### PR TITLE
CHECKOUT-1326 Add email field in billing address

### DIFF
--- a/src/payment/mappers/map-to-billing-address.js
+++ b/src/payment/mappers/map-to-billing-address.js
@@ -6,5 +6,12 @@ import mapToAddress from './map-to-address';
  * @returns {Object}
  */
 export default function mapToBillingAddress(data) {
-    return mapToAddress(data, 'billingAddress');
+    const { customer = {} } = data;
+    const address = mapToAddress(data, 'billingAddress');
+
+    if (customer.email) {
+        address.email = customer.email;
+    }
+
+    return address;
 }

--- a/test/payment/mappers/map-to-address.spec.js
+++ b/test/payment/mappers/map-to-address.spec.js
@@ -8,22 +8,22 @@ describe('mapToAddress', () => {
         data = paymentRequestDataMock;
     });
 
-    it('should map to billing address', () => {
-        const output = mapToAddress(data, 'billingAddress');
+    it('should map to shipping address', () => {
+        const output = mapToAddress(data, 'shippingAddress');
 
         expect(output).toEqual({
-            city: data.billingAddress.city,
-            company: data.billingAddress.company,
-            country_code: data.billingAddress.countryCode,
-            country: data.billingAddress.country,
-            first_name: data.billingAddress.firstName,
-            last_name: data.billingAddress.lastName,
-            phone: data.billingAddress.phone,
-            state_code: data.billingAddress.provinceCode,
-            state: data.billingAddress.province,
-            street_1: data.billingAddress.addressLine1,
-            street_2: data.billingAddress.addressLine2,
-            zip: data.billingAddress.postCode,
+            city: data.shippingAddress.city,
+            company: data.shippingAddress.company,
+            country_code: data.shippingAddress.countryCode,
+            country: data.shippingAddress.country,
+            first_name: data.shippingAddress.firstName,
+            last_name: data.shippingAddress.lastName,
+            phone: data.shippingAddress.phone,
+            state_code: data.shippingAddress.provinceCode,
+            state: data.shippingAddress.province,
+            street_1: data.shippingAddress.addressLine1,
+            street_2: data.shippingAddress.addressLine2,
+            zip: data.shippingAddress.postCode,
         });
     });
 });

--- a/test/payment/mappers/map-to-billing-address.spec.js
+++ b/test/payment/mappers/map-to-billing-address.spec.js
@@ -1,0 +1,30 @@
+import mapToBillingAddress from '../../../src/payment/mappers/map-to-billing-address';
+import paymentRequestDataMock from '../../mocks/payment-request-data';
+
+describe('mapToBillingAddress', () => {
+    let data;
+
+    beforeEach(() => {
+        data = paymentRequestDataMock;
+    });
+
+    it('should map to billing address', () => {
+        const output = mapToBillingAddress(data);
+
+        expect(output).toEqual({
+            city: data.billingAddress.city,
+            company: data.billingAddress.company,
+            country_code: data.billingAddress.countryCode,
+            country: data.billingAddress.country,
+            email: data.customer.email,
+            first_name: data.billingAddress.firstName,
+            last_name: data.billingAddress.lastName,
+            phone: data.billingAddress.phone,
+            state_code: data.billingAddress.provinceCode,
+            state: data.billingAddress.province,
+            street_1: data.billingAddress.addressLine1,
+            street_2: data.billingAddress.addressLine2,
+            zip: data.billingAddress.postCode,
+        });
+    });
+});


### PR DESCRIPTION
## What?
As per above

## Why?
Cybersource requires an email address to be apply to proceed

## Testing / Proof
Manual testing
<img width="319" alt="screen shot 2017-01-16 at 12 09 08 pm" src="https://cloud.githubusercontent.com/assets/22089936/21968069/a645921a-dbe4-11e6-90d8-38ba2aa329ab.png">



ping @bigcommerce-labs/checkout 
