### PR TITLE
Generate coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.log
+coverage
 node_modules

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 **/.*
 bower.json
+coverage
 gulpfile.js
 karma.config.js
 src

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,3 +1,5 @@
+var _ = require('lodash');
+var karmaCoverage = require('karma-coverage');
 var karmaJasmine = require('karma-jasmine');
 var karmaMochaReporter = require('karma-mocha-reporter');
 var karmaPhantomJsLauncher = require('karma-phantomjs-launcher');
@@ -11,6 +13,17 @@ function configureKarma(config) {
         browsers: [
             'PhantomJS',
         ],
+        coverageReporter: {
+            check: {
+                global: {
+                    lines: 85,
+                },
+            },
+            reporters: [
+                { type: 'html' },
+                { type: 'text' },
+            ],
+        },
         files: [
             './node_modules/jasmine-ajax/lib/mock-ajax.js',
             './test/index.js',
@@ -19,6 +32,7 @@ function configureKarma(config) {
             'jasmine',
         ],
         plugins: [
+            karmaCoverage,
             karmaJasmine,
             karmaMochaReporter,
             karmaPhantomJsLauncher,
@@ -26,19 +40,34 @@ function configureKarma(config) {
             karmaWebpack,
         ],
         preprocessors: {
+            './src/index.js': ['coverage'],
             './test/index.js': ['webpack', 'sourcemap'],
         },
         reporters: [
             'mocha',
+            'coverage',
         ],
         webpack: {
             devtool: 'inline-source-map',
-            module: webpackConfig.module,
+            module: getWebpackModule(),
         },
         webpackMiddleware: {
             noInfo: true,
         },
     });
+}
+
+function getWebpackModule() {
+    var module = _.cloneDeep(webpackConfig.module);
+    var babelLoader = _.find(module.loaders, { loader: 'babel' });
+
+    if (babelLoader) {
+        babelLoader.query = babelLoader.query || {};
+        babelLoader.query.plugins = babelLoader.query.plugins || [];
+        babelLoader.query.plugins.push('istanbul');
+    }
+
+    return module;
 }
 
 module.exports = configureKarma;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "babel-core": "6.14.0",
     "babel-loader": "6.2.5",
+    "babel-plugin-istanbul": "3.0.0",
     "babel-preset-es2015": "6.14.0",
     "eslint": "3.4.0",
     "eslint-config-airbnb-base": "7.0.0",
@@ -34,6 +35,7 @@
     "jasmine-ajax": "3.2.0",
     "jasmine-core": "2.5.1",
     "karma": "1.2.0",
+    "karma-coverage": "1.1.1",
     "karma-jasmine": "1.0.2",
     "karma-mocha-reporter": "2.1.0",
     "karma-phantomjs-launcher": "1.0.2",


### PR DESCRIPTION
## What?
Generate a coverage report when you run `npm test`.

## Why?
To see a test coverage report. Make sure the coverage meets the minimum threshold.

## Testing / Proof
![screen shot 2017-01-16 at 5 18 45 pm](https://cloud.githubusercontent.com/assets/667603/22001647/95ae65d8-dc9a-11e6-9852-a14022c21c1f.png)

@bigcommerce-labs/checkout 
