### PR TITLE
fix(payment): Map id to sagepay

### DIFF
--- a/src/payment-method/map-to-id.js
+++ b/src/payment-method/map-to-id.js
@@ -1,4 +1,4 @@
-import { BRAINTREE, BRAINTREE_PAYPAL } from './payment-methods';
+import { BRAINTREE, BRAINTREE_PAYPAL, PROTX_VSP_DIRECT, SAGE_PAY } from './payment-methods';
 
 /**
  * Map to gateway
@@ -8,6 +8,10 @@ import { BRAINTREE, BRAINTREE_PAYPAL } from './payment-methods';
 export default function mapToId(paymentMethod) {
     if (paymentMethod.id === BRAINTREE_PAYPAL) {
         return BRAINTREE;
+    }
+
+    if (paymentMethod.id === PROTX_VSP_DIRECT) {
+        return SAGE_PAY;
     }
 
     return paymentMethod.id;

--- a/src/payment-method/payment-methods.js
+++ b/src/payment-method/payment-methods.js
@@ -1,2 +1,4 @@
 export const BRAINTREE = 'braintree';
 export const BRAINTREE_PAYPAL = 'braintreepaypal';
+export const PROTX_VSP_DIRECT = 'protxvspdirect';
+export const SAGE_PAY = 'sagepay';

--- a/test/payment-method/map-to-id.spec.js
+++ b/test/payment-method/map-to-id.spec.js
@@ -4,10 +4,17 @@ import * as PAYMENT_METHODS from '../../src/payment-method/payment-methods';
 describe('mapToId', () => {
     let paymentMethod;
 
-    it('should translate payment method id if neccessary', () => {
+    it('should map "braintreepaypal" to "braintree"', () => {
         paymentMethod = { id: PAYMENT_METHODS.BRAINTREE_PAYPAL };
         expect(mapToId(paymentMethod)).toEqual(PAYMENT_METHODS.BRAINTREE);
+    });
 
+    it('should map "protxvspdirect" to "sagepay"', () => {
+        paymentMethod = { id: PAYMENT_METHODS.PROTX_VSP_DIRECT };
+        expect(mapToId(paymentMethod)).toEqual(PAYMENT_METHODS.SAGE_PAY);
+    });
+
+    it('should not do any mapping if it is not neccessary', () => {
         paymentMethod = { id: PAYMENT_METHODS.BRAINTREE };
         expect(mapToId(paymentMethod)).toEqual(PAYMENT_METHODS.BRAINTREE);
     });


### PR DESCRIPTION
## What?
Map `protxvspdirect` to `sagepay` before sending the request to BigPay.

## Why?
`protxvspdirect` payment method is called `sagepay` in BigPay. Therefore, we need to transform the data before sending the request.

## Testing / Proof
Unit

ping @bigcommerce-labs/payments @bigcommerce-labs/checkout 
