### PR TITLE
PAYMENTS-889 Forward returnUrl of order instead of payment object if possible

### DIFF
--- a/src/payment/mappers/map-to-payment.js
+++ b/src/payment/mappers/map-to-payment.js
@@ -15,7 +15,7 @@ export default function mapToPayment(data) {
         device_info: quoteMeta.request ? quoteMeta.request.deviceSessionId : null,
         gateway: mapToId(paymentMethod),
         notify_url: order.callbackUrl,
-        return_url: order.payment ? order.payment.returnUrl : null,
+        return_url: paymentMethod.returnUrl || (order.payment ? order.payment.returnUrl : null),
     };
 
     const nonce = payment.nonce || paymentMethod.nonce;

--- a/src/payment/offsite-mappers/map-to-payload.js
+++ b/src/payment/offsite-mappers/map-to-payload.js
@@ -26,7 +26,7 @@ export default function mapToPayload(data) {
             page_title: document.title,
             payment_method_id: mapToId(paymentMethod),
             reference_id: toString(order.orderId),
-            return_url: order.payment ? order.payment.returnUrl : null,
+            return_url: paymentMethod.returnUrl || (order.payment ? order.payment.returnUrl : null),
         },
         mapToBillingAddress(data),
         mapToCustomer(data),

--- a/test/mocks/payment-request-data.js
+++ b/test/mocks/payment-request-data.js
@@ -45,9 +45,6 @@ const paymentRequestDataMock = {
             integerAmount: 500,
         },
         orderId: '123',
-        payment: {
-            returnUrl: '/checkout',
-        },
         shipping: {
             integerAmount: 1000,
         },
@@ -71,6 +68,7 @@ const paymentRequestDataMock = {
     paymentMethod: {
         id: 'paypalprous',
         type: API,
+        returnUrl: '/checkout',
     },
     quoteMeta: {
         request: {

--- a/test/payment/mappers/map-to-payment.spec.js
+++ b/test/payment/mappers/map-to-payment.spec.js
@@ -1,3 +1,4 @@
+import omit from 'lodash/omit';
 import merge from 'lodash/merge';
 import * as mapToCreditCardModule from '../../../src/payment/mappers/map-to-credit-card';
 import mapToPayment from '../../../src/payment/mappers/map-to-payment';
@@ -20,7 +21,7 @@ describe('mapToPayment', () => {
             device_info: data.quoteMeta.request.deviceSessionId,
             gateway: data.paymentMethod.id,
             notify_url: data.order.callbackUrl,
-            return_url: data.order.payment.returnUrl,
+            return_url: data.paymentMethod.returnUrl,
         });
     });
 
@@ -40,7 +41,17 @@ describe('mapToPayment', () => {
             device_info: data.quoteMeta.request.deviceSessionId,
             gateway: data.paymentMethod.id,
             notify_url: data.order.callbackUrl,
-            return_url: data.order.payment.returnUrl,
+            return_url: data.paymentMethod.returnUrl,
         });
+    });
+
+    it('should use the return URL contained in the order object as a fallback', () => {
+        data = merge({}, data, {
+            paymentMethod: omit(data.paymentMethod, 'returnUrl'),
+        });
+
+        const output = mapToPayment(data);
+
+        expect(output.return_url).toEqual(data.paymentMethod.returnUrl);
     });
 });

--- a/test/payment/offsite-mappers/map-to-payload.spec.js
+++ b/test/payment/offsite-mappers/map-to-payload.spec.js
@@ -1,3 +1,4 @@
+import omit from 'lodash/omit';
 import merge from 'lodash/merge';
 import * as mapToBillingAddressModule from '../../../src/payment/offsite-mappers/map-to-billing-address';
 import * as mapToCustomerModule from '../../../src/payment/offsite-mappers/map-to-customer';
@@ -42,9 +43,19 @@ describe('mapToPayload', () => {
             page_title: document.title,
             payment_method_id: data.paymentMethod.id,
             reference_id: data.order.orderId,
-            return_url: data.order.payment.returnUrl,
+            return_url: data.paymentMethod.returnUrl,
             shippingAddress: 'shippingAddress',
             store: 'store',
         });
+    });
+
+    it('should use the return URL contained in the order object as a fallback', () => {
+        data = merge({}, data, {
+            paymentMethod: omit(data.paymentMethod, 'returnUrl'),
+        });
+
+        const output = mapToPayload(data);
+
+        expect(output.return_url).toEqual(data.paymentMethod.returnUrl);
     });
 });


### PR DESCRIPTION
## What?
Use `paymentMethod.returnUrl` if it is defined.

## Why?
So it can be forwarded to BigPay. Eventually, BCApp will only return `returnUrl` in `paymentMethod` object. But for now, simply do a conditional check and forward any known value.

## Testing / Proof
Unit

@bigcommerce-labs/checkout @bigcommerce-labs/payments 
