### PR TITLE
PAYMENTS-212: Move v1 mappers to v1 folder

### DIFF
--- a/src/payment/payment-submitter.js
+++ b/src/payment/payment-submitter.js
@@ -1,5 +1,5 @@
 import { API } from './payment-types';
-import PayloadMapper from './payment-mappers/payload-mapper';
+import PayloadMapper from './v1/payment-mappers/payload-mapper';
 import RequestSender from '../common/http-request/request-sender';
 import UrlHelper from './url-helper';
 

--- a/src/payment/v1/payment-mappers/customer-mapper.js
+++ b/src/payment/v1/payment-mappers/customer-mapper.js
@@ -1,4 +1,4 @@
-import { omitNil, toString } from '../../common/utils';
+import { omitNil, toString } from '../../../common/utils';
 
 export default class CustomerMapper {
     /**

--- a/src/payment/v1/payment-mappers/order-mapper.js
+++ b/src/payment/v1/payment-mappers/order-mapper.js
@@ -1,4 +1,4 @@
-import { omitNil, toString } from '../../common/utils';
+import { omitNil, toString } from '../../../common/utils';
 
 export default class OrderMapper {
     /**

--- a/src/payment/v1/payment-mappers/payload-mapper.js
+++ b/src/payment/v1/payment-mappers/payload-mapper.js
@@ -1,4 +1,4 @@
-import { omitNil } from '../../common/utils';
+import { omitNil } from '../../../common/utils';
 import CustomerMapper from './customer-mapper';
 import OrderMapper from './order-mapper';
 import PaymentMapper from './payment-mapper';

--- a/src/payment/v1/payment-mappers/payment-mapper.js
+++ b/src/payment/v1/payment-mappers/payment-mapper.js
@@ -1,6 +1,6 @@
 import objectAssign from 'object-assign';
-import PaymentMethodIdMapper from '../payment-method-mappers/payment-method-id-mapper';
-import { omitNil, toNumber } from '../../common/utils';
+import PaymentMethodIdMapper from '../../payment-method-mappers/payment-method-id-mapper';
+import { omitNil, toNumber } from '../../../common/utils';
 
 export default class PaymentMapper {
     /**

--- a/src/payment/v1/payment-mappers/store-mapper.js
+++ b/src/payment/v1/payment-mappers/store-mapper.js
@@ -1,4 +1,4 @@
-import { omitNil, toString } from '../../common/utils';
+import { omitNil, toString } from '../../../common/utils';
 
 export default class StoreMapper {
     /**

--- a/test/payment/v1/payment-mappers/customer-mapper.spec.js
+++ b/test/payment/v1/payment-mappers/customer-mapper.spec.js
@@ -1,5 +1,5 @@
-import CustomerMapper from '../../../src/payment/payment-mappers/customer-mapper';
-import paymentRequestDataMock from '../../mocks/payment-request-data';
+import CustomerMapper from '../../../../src/payment/v1/payment-mappers/customer-mapper';
+import paymentRequestDataMock from '../../../mocks/payment-request-data';
 
 describe('CustomerMapper', () => {
     let customerMapper;

--- a/test/payment/v1/payment-mappers/order-mapper.spec.js
+++ b/test/payment/v1/payment-mappers/order-mapper.spec.js
@@ -1,5 +1,5 @@
-import OrderMapper from '../../../src/payment/payment-mappers/order-mapper';
-import paymentRequestDataMock from '../../mocks/payment-request-data';
+import OrderMapper from '../../../../src/payment/v1/payment-mappers/order-mapper';
+import paymentRequestDataMock from '../../../mocks/payment-request-data';
 
 describe('OrderMapper', () => {
     let data;

--- a/test/payment/v1/payment-mappers/payload-mapper.spec.js
+++ b/test/payment/v1/payment-mappers/payload-mapper.spec.js
@@ -1,5 +1,5 @@
-import PayloadMapper from '../../../src/payment/payment-mappers/payload-mapper';
-import paymentRequestDataMock from '../../mocks/payment-request-data';
+import PayloadMapper from '../../../../src/payment/v1/payment-mappers/payload-mapper';
+import paymentRequestDataMock from '../../../mocks/payment-request-data';
 
 describe('PayloadMapper', () => {
     let customerMapper;

--- a/test/payment/v1/payment-mappers/payment-mapper.spec.js
+++ b/test/payment/v1/payment-mappers/payment-mapper.spec.js
@@ -1,7 +1,7 @@
 import omit from 'lodash/omit';
 import merge from 'lodash/merge';
-import PaymentMapper from '../../../src/payment/payment-mappers/payment-mapper';
-import paymentRequestDataMock from '../../mocks/payment-request-data';
+import PaymentMapper from '../../../../src/payment/v1/payment-mappers/payment-mapper';
+import paymentRequestDataMock from '../../../mocks/payment-request-data';
 
 describe('PaymentMapper', () => {
     let data;

--- a/test/payment/v1/payment-mappers/store-mapper.spec.js
+++ b/test/payment/v1/payment-mappers/store-mapper.spec.js
@@ -1,5 +1,5 @@
-import paymentRequestDataMock from '../../mocks/payment-request-data';
-import StoreMapper from '../../../src/payment/payment-mappers/store-mapper';
+import paymentRequestDataMock from '../../../mocks/payment-request-data';
+import StoreMapper from '../../../../src/payment/v1/payment-mappers/store-mapper';
 
 describe('StoreMapper', () => {
     let data;


### PR DESCRIPTION
## What?
Move v1 mappers to v1 folder.

## Why?
We are introducing v2 mappers in #36. So, we should move all v1 mappers to a dedicated folder for better organisation.

## Testing / Proof
Unit

ping @bigcommerce-labs/checkout @bigcommerce-labs/payments 
