### PR TITLE
fix(payment): Get the host value from config object

### DIFF
--- a/src/client/client.js
+++ b/src/client/client.js
@@ -1,5 +1,7 @@
+import objectAssign from 'object-assign';
 import OffsitePaymentInitializer from '../payment/offsite-payment-initializer';
 import PaymentSubmitter from '../payment/payment-submitter';
+import DEFAULT_CONFIG from './default-config';
 
 export default class Client {
     /**
@@ -7,10 +9,11 @@ export default class Client {
      * @returns {Client}
      */
     static create(config) {
-        const paymentSubmitter = PaymentSubmitter.create(config);
-        const offsitePaymentInitializer = OffsitePaymentInitializer.create(config);
+        const clientConfig = objectAssign({}, DEFAULT_CONFIG, config);
+        const paymentSubmitter = PaymentSubmitter.create(clientConfig);
+        const offsitePaymentInitializer = OffsitePaymentInitializer.create(clientConfig);
 
-        return new Client(config, paymentSubmitter, offsitePaymentInitializer);
+        return new Client(clientConfig, paymentSubmitter, offsitePaymentInitializer);
     }
 
     /**

--- a/src/client/default-config.js
+++ b/src/client/default-config.js
@@ -1,0 +1,5 @@
+const DEFAULT_CONFIG = {
+    host: '',
+};
+
+export default DEFAULT_CONFIG;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import Client from './client/client';
 
 /**
- * @param {Object} config
+ * @param {Object} [config]
  * @returns {Client}
  */
 export function createClient(config) {

--- a/src/payment/url-helper.js
+++ b/src/payment/url-helper.js
@@ -1,17 +1,19 @@
 export default class UrlHelper {
     /**
-     * @param {string} host
+     * @param {Object} config
+     * @param {string} config.host
      * @returns {CustomerMapper}
      */
-    static create(host) {
-        return new UrlHelper(host);
+    static create(config) {
+        return new UrlHelper(config);
     }
 
     /**
-     * @param {string} host
+     * @param {Object} config
+     * @param {string} config.host
      * @returns {void}
      */
-    constructor(host) {
+    constructor({ host }) {
         /**
          * @private
          * @type {string}

--- a/test/client/client.spec.js
+++ b/test/client/client.spec.js
@@ -11,7 +11,7 @@ describe('Client', () => {
     let offsitePaymentInitializer;
 
     beforeEach(() => {
-        config = { host: 'https://bcapp.dev' };
+        config = { host: 'https://bigpay.dev' };
 
         paymentSubmitter = {
             submitPayment: jasmine.createSpy('submitPayment'),

--- a/test/payment/client-token-generator.spec.js
+++ b/test/payment/client-token-generator.spec.js
@@ -29,7 +29,8 @@ describe('ClientTokenGenerator', () => {
     });
 
     it('creates an instance of ClientTokenGenerator', () => {
-        const instance = ClientTokenGenerator.create();
+        const config = { host: 'https://bigpay.dev' };
+        const instance = ClientTokenGenerator.create(config);
 
         expect(instance instanceof ClientTokenGenerator).toBeTruthy();
     });

--- a/test/payment/offsite-payment-initializer.spec.js
+++ b/test/payment/offsite-payment-initializer.spec.js
@@ -36,7 +36,8 @@ describe('OffsitePaymentInitializer', () => {
     });
 
     it('creates an instance of OffsitePaymentInitializer', () => {
-        const instance = OffsitePaymentInitializer.create();
+        const config = { host: 'https://bigpay.dev' };
+        const instance = OffsitePaymentInitializer.create(config);
 
         expect(instance instanceof OffsitePaymentInitializer).toBeTruthy();
     });

--- a/test/payment/payment-submitter.spec.js
+++ b/test/payment/payment-submitter.spec.js
@@ -34,7 +34,8 @@ describe('PaymentSubmitter', () => {
     });
 
     it('creates an instance of PaymentSubmitter', () => {
-        const instance = PaymentSubmitter.create();
+        const config = { host: 'https://bigpay.dev' };
+        const instance = PaymentSubmitter.create(config);
 
         expect(instance instanceof PaymentSubmitter).toBeTruthy();
     });

--- a/test/payment/url-helper.spec.js
+++ b/test/payment/url-helper.spec.js
@@ -6,11 +6,11 @@ describe('UrlHelper', () => {
 
     beforeEach(() => {
         host = 'https://bigpay.com';
-        urlHelper = new UrlHelper(host);
+        urlHelper = new UrlHelper({ host });
     });
 
     it('creates an instance of UrlHelper', () => {
-        const instance = UrlHelper.create();
+        const instance = UrlHelper.create({ host });
 
         expect(instance instanceof UrlHelper).toBeTruthy();
     });


### PR DESCRIPTION
## What?
* The first argument for `UrlHelper` should be a config object instead of a string.
* Some background info: I did some refactoring earlier but didn't end up releasing it to BCApp master. Now I need to change something for AfterPay with the refactored code. That's when I discover this issue.

## Why?
* Otherwise, `UrlHelper` doesn't know how to get the host URL value, therefore cannot return the correct endpoint URLs.

## Testing / Proof
* Unit
* Manual

`POST https://bigpay.integration.zone/api/public/v1/orders/payments`
<img width="1334" alt="screen shot 2017-07-01 at 9 22 14 am" src="https://user-images.githubusercontent.com/667603/27756893-e582d410-5e3e-11e7-8c75-08f15d4c0550.png">

`POST https://bigpay.integration.zone/pay/initialize`
<img width="1339" alt="screen shot 2017-07-01 at 9 21 27 am" src="https://user-images.githubusercontent.com/667603/27756885-d83fc006-5e3e-11e7-98e7-1c6a21d3ac2c.png">

ping @bigcommerce-labs/checkout @bigcommerce-labs/payments 
