### PR TITLE
PAYMENTS-1723: Maps BT VisaCheckout to braintree

### DIFF
--- a/src/payment/payment-method-ids.js
+++ b/src/payment/payment-method-ids.js
@@ -1,2 +1,3 @@
 export const BRAINTREE = 'braintree';
 export const BRAINTREE_PAYPAL = 'braintreepaypal';
+export const BRAINTREE_VISACHECKOUT = 'braintreevisacheckout';

--- a/src/payment/payment-method-mappers/payment-method-id-mapper.js
+++ b/src/payment/payment-method-mappers/payment-method-id-mapper.js
@@ -1,4 +1,4 @@
-import { BRAINTREE, BRAINTREE_PAYPAL } from '../payment-method-ids';
+import { BRAINTREE, BRAINTREE_PAYPAL, BRAINTREE_VISACHECKOUT } from '../payment-method-ids';
 import { MULTI_OPTION } from '../payment-method-types';
 
 export default class PaymentMethodIdMapper {
@@ -20,7 +20,7 @@ export default class PaymentMethodIdMapper {
             id = paymentMethod.gateway;
         }
 
-        if (id === BRAINTREE_PAYPAL) {
+        if (id === BRAINTREE_PAYPAL || id === BRAINTREE_VISACHECKOUT) {
             return BRAINTREE;
         }
 

--- a/test/payment/payment-method-mappers/payment-method-id-mapper.spec.js
+++ b/test/payment/payment-method-mappers/payment-method-id-mapper.spec.js
@@ -21,6 +21,11 @@ describe('PaymentMethodIdMapper', () => {
         expect(paymentMethodIdMapper.mapToId(paymentMethod)).toEqual(PAYMENT_METHODS.BRAINTREE);
     });
 
+    it('returns "braintree" if the payment method is "braintreevisacheckout"', () => {
+        paymentMethod = { id: PAYMENT_METHODS.BRAINTREE_VISACHECKOUT };
+        expect(paymentMethodIdMapper.mapToId(paymentMethod)).toEqual(PAYMENT_METHODS.BRAINTREE);
+    });
+
     it('returns the "gateway" field of the payment method if it is a multi-option method', () => {
         paymentMethod = {
             id: PAYMENT_METHODS.BRAINTREE_PAYPAL,


### PR DESCRIPTION
## What?
Maps VisaCheckout to Braintree

## Why?
Because of the way VisaCheckout is configured on the Backend. 

## Testing / Proof
Unit tests

ping @davidchin @filakhtov @bigcommerce-labs/payments 
