### PR TITLE
INT-42 Add customer code to payment mapper

### DIFF
--- a/src/payment/v1/payment-mappers/payment-mapper.js
+++ b/src/payment/v1/payment-mappers/payment-mapper.js
@@ -66,6 +66,7 @@ export default class PaymentMapper {
 
         return omitNil({
             account_name: payment.ccName,
+            customer_code: payment.ccCustomerCode,
             month: payment.ccExpiry ? toNumber(payment.ccExpiry.month) : null,
             number: payment.ccNumber,
             verification_value: payment.ccCvv,

--- a/test/mocks/payment-request-data.js
+++ b/test/mocks/payment-request-data.js
@@ -84,6 +84,7 @@ const paymentRequestDataMock = {
     },
     payment: {
         ccCvv: '123',
+        ccCustomerCode: 'XYZ',
         ccExpiry: {
             month: 1,
             year: 2018,

--- a/test/payment/v1/payment-mappers/payment-mapper.spec.js
+++ b/test/payment/v1/payment-mappers/payment-mapper.spec.js
@@ -30,6 +30,7 @@ describe('PaymentMapper', () => {
         expect(output).toEqual({
             credit_card: {
                 account_name: data.payment.ccName,
+                customer_code: data.payment.ccCustomerCode,
                 number: data.payment.ccNumber,
                 month: parseInt(data.payment.ccExpiry.month, 10),
                 verification_value: data.payment.ccCvv,


### PR DESCRIPTION
## What?
Add customer code to payment mapper.

## Why?
Vantiv provides the option for shoppers to provide a customer code.

## Testing / Proof
Updated payment-mapper spec

ping @bigcommerce-labs/payments 
