### PR TITLE
PAYMENTS-1902: map referrer id to payment if available

### DIFF
--- a/src/payment/v1/payment-mappers/payment-mapper.js
+++ b/src/payment/v1/payment-mappers/payment-mapper.js
@@ -46,6 +46,12 @@ export default class PaymentMapper {
             return_url: paymentMethod.returnUrl || (order.payment ? order.payment.returnUrl : null),
         };
 
+        const method = payment.method;
+
+        if (method) {
+            objectAssign(payload, { method });
+        }
+
         const nonce = payment.nonce || paymentMethod.nonce;
 
         if (nonce) {

--- a/test/payment/v1/payment-mappers/payment-mapper.spec.js
+++ b/test/payment/v1/payment-mappers/payment-mapper.spec.js
@@ -69,6 +69,20 @@ describe('PaymentMapper', () => {
         });
     });
 
+    it('maps the input object into a payment object with method', () => {
+        data = merge({}, data, {
+            payment: {
+                method: 'paypal',
+            },
+        });
+
+        const output = paymentMapper.mapToPayment(data);
+
+        expect(output).toEqual(jasmine.objectContaining({
+            method: data.payment.method,
+        }));
+    });
+
     it('uses the return URL contained in the order object as a fallback', () => {
         data = merge({}, data, {
             order: {


### PR DESCRIPTION
## What?
Maps the referrer id (method) to payment data if supplied

## Why?
To tell BigPay which variation of the payment method we're paying with so that we can send a referrer id to paypal and other providers

## Testing / Proof
unit tests

ping @bigcommerce-labs/payments @bigcommerce-labs/checkout @filakhtov 

