### PR TITLE
CHECKOUT-2509 Send shipping method to BigPay

### DIFF
--- a/src/payment/v1/payment-mappers/order-mapper.js
+++ b/src/payment/v1/payment-mappers/order-mapper.js
@@ -21,6 +21,7 @@ export default class OrderMapper {
             currency: order.currency,
             id: order.orderId ? toString(order.orderId) : null,
             items: this.mapToItems(data),
+            shipping: this.mapToShipping(data),
             shipping_address: this.mapToShippingAddress(data),
             token: order.token,
             totals: this.mapToOrderTotals(data),
@@ -41,6 +42,23 @@ export default class OrderMapper {
         }
 
         return address;
+    }
+
+    /**
+     * @private
+     * @param  {PaymentRequestData} data
+     * @return {Shipping[]}
+     */
+    mapToShipping(data) {
+        const { description } = data.shippingOption || {};
+
+        if (description) {
+            return [{
+                method: description,
+            }];
+        }
+
+        return [];
     }
 
     /**

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -9,6 +9,7 @@
  * @property {PaymentMethodData} paymentMethod
  * @property {QuoteMetaData} quoteMeta
  * @property {AddressData} shippingAddress
+ * @property {ShippingData} shippingOption
  * @property {StoreData} store
  */
 
@@ -114,6 +115,24 @@
  */
 
 /**
+ * @typedef {Object} ShippingData
+ * @property {string} description
+ * @property {string} formattedPrice
+ * @property {string} id
+ * @property {string} imageUrl
+ * @property {number} method
+ * @property {string} module
+ * @property {number} price
+ * @property {boolean} selected
+ * @property {string} transitTime
+ */
+
+/**
  * @typedef {Object} Coupon
  * @property {string} code
  */
+
+ /**
+  * @typedef {Object} Shipping
+  * @property {string} method
+  */

--- a/test/mocks/payment-request-data.js
+++ b/test/mocks/payment-request-data.js
@@ -129,6 +129,17 @@ const paymentRequestDataMock = {
         provinceCode: 'CA',
         province: 'California',
     },
+    shippingOption: {
+        description: 'Free Shipping',
+        formattedPrice: '$15.00',
+        id: '0:f877ffc1fac6f544e36746c38d90a2bf',
+        imageUrl: '',
+        method: -1,
+        module: 'freeshipping',
+        price: 15,
+        selected: true,
+        transitTime: '',
+    },
     source: 'bcapp-checkout-uco',
     store: {
         cartLink: '/cart',

--- a/test/payment/v1/payment-mappers/order-mapper.spec.js
+++ b/test/payment/v1/payment-mappers/order-mapper.spec.js
@@ -46,6 +46,9 @@ describe('OrderMapper', () => {
                     sku: data.cart.items[0].sku,
                 },
             ],
+            shipping: [{
+                method: data.shippingOption.description,
+            }],
             shipping_address: {
                 city: data.shippingAddress.city,
                 company: data.shippingAddress.company,
@@ -79,6 +82,7 @@ describe('OrderMapper', () => {
             coupons: [],
             billing_address: {},
             items: [],
+            shipping: [],
             shipping_address: {},
             totals: {},
         });


### PR DESCRIPTION
## What?
Send the shippingOption method to BigPay for CyberSource to consume.

## Why?
Required for fraud detection.

## Testing / Proof
Unit / Manual

ping @bigcommerce-labs/checkout @bigcommerce-labs/payments @wedy 
