### PR TITLE
feat(provider) INT-69 Added product_id:integerId to order-mapper to s…

### DIFF
--- a/src/payment/v1/payment-mappers/order-mapper.js
+++ b/src/payment/v1/payment-mappers/order-mapper.js
@@ -118,6 +118,7 @@ export default class OrderMapper {
 
         return cart.items.map(itemData => omitNil({
             code: itemData.id,
+            variant_id: itemData.variantId,
             name: itemData.name,
             price: itemData.integerAmount,
             quantity: itemData.quantity,

--- a/test/mocks/payment-request-data.js
+++ b/test/mocks/payment-request-data.js
@@ -47,6 +47,7 @@ const paymentRequestDataMock = {
                 quantity: 1,
                 sku: '123456789',
                 type: 'ItemPhysicalEntity',
+                variantId: 13,
             },
         ],
     },

--- a/test/payment/v1/payment-mappers/order-mapper.spec.js
+++ b/test/payment/v1/payment-mappers/order-mapper.spec.js
@@ -42,6 +42,7 @@ describe('OrderMapper', () => {
                     code: data.cart.items[0].id,
                     name: data.cart.items[0].name,
                     price: data.cart.items[0].integerAmount,
+                    variant_id: data.cart.items[0].variantId,
                     quantity: data.cart.items[0].quantity,
                     sku: data.cart.items[0].sku,
                 },


### PR DESCRIPTION
…upport Vantiv MC/V/L3 request data

## What?
Added the primary-key integer id of the product. 

## Why?
- It is a data requirement for Vantiv MC/V/L3 
- It allows for card brands to reference a product in a store from a purchase 
- The UUID that is currently available as 'id'
--  Is too large to fit in the Vantiv api field for this data (product code) without truncation
-- Does not support referencing a product easily because the UUID is not seen/used in the Merchant Control Panel. The ID is used (in URL for product view), but not displayed. Subsequent work will surface this value.

## Testing / Proof
Updated order-mapper.spec.js to include assertions on the mapped product_id:integerId value.

## Etc
Multiple projects are modified for this ticket, please see original JIRA ticket for more context.

ping {suggested reviewers}