### PR TITLE
feat(payment) PAYMENTS-1983 Map shouldSaveIntrument to bigpay equivalent

### DIFF
--- a/src/payment/v1/payment-mappers/payment-mapper.js
+++ b/src/payment/v1/payment-mappers/payment-mapper.js
@@ -44,6 +44,7 @@ export default class PaymentMapper {
             gateway: this.paymentMethodIdMapper.mapToId(paymentMethod),
             notify_url: order.callbackUrl,
             return_url: paymentMethod.returnUrl || (order.payment ? order.payment.returnUrl : null),
+            vault_payment_instrument: payment.shouldSaveInstrument || null,
         };
 
         const method = payment.method;

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -89,6 +89,7 @@
  * @property {number} ccExpiry.year
  * @property {string} ccName
  * @property {string} ccNumber
+ * @property {?boolean} shouldSaveInstrument
  */
 
 /**

--- a/test/mocks/payment-request-data.js
+++ b/test/mocks/payment-request-data.js
@@ -103,6 +103,7 @@ const paymentRequestDataMock = {
         ccName: 'Foo Bar',
         ccNumber: '4007000000027',
         ccCustomerCode: 'XYZ',
+        shouldSaveInstrument: true,
     },
     paymentMethod: {
         id: 'paypalprous',

--- a/test/payment/v1/payment-mappers/payment-mapper.spec.js
+++ b/test/payment/v1/payment-mappers/payment-mapper.spec.js
@@ -43,6 +43,7 @@ describe('PaymentMapper', () => {
             gateway: data.paymentMethod.id,
             notify_url: data.order.callbackUrl,
             return_url: data.paymentMethod.returnUrl,
+            vault_payment_instrument: data.payment.shouldSaveInstrument,
         });
     });
 
@@ -66,6 +67,7 @@ describe('PaymentMapper', () => {
             gateway: data.paymentMethod.id,
             notify_url: data.order.callbackUrl,
             return_url: data.paymentMethod.returnUrl,
+            vault_payment_instrument: data.payment.shouldSaveInstrument,
         });
     });
 


### PR DESCRIPTION
## What?
Passes a flag to bigpay which prompts it to store the supplied credit card

## Why?
To allow customers to store their cards

## Testing / Proof
Unit tests

Related: https://github.com/bigcommerce-labs/ng-checkout/pull/670

ping @bigcommerce-labs/payments @bigcommerce-labs/checkout @cwalsh @davidchin 
