### PR TITLE
CHECKOUT-2702: Bump form-poster to fix callback getting called prematurely

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "deep-assign": "^2.0.0",
-    "form-poster": "git+ssh://git@github.com/bigcommerce-labs/form-poster-js.git#1.0.1",
+    "form-poster": "git+ssh://git@github.com/bigcommerce-labs/form-poster-js.git#1.1.1",
     "object-assign": "^4.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2038,9 +2038,9 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
-"form-poster@git+ssh://git@github.com/bigcommerce-labs/form-poster-js.git#1.0.1":
-  version "1.0.1"
-  resolved "git+ssh://git@github.com/bigcommerce-labs/form-poster-js.git#f5df7d86bf70c1910d6ddd4aa07328916c7c8052"
+"form-poster@git+ssh://git@github.com/bigcommerce-labs/form-poster-js.git#1.1.1":
+  version "1.1.1"
+  resolved "git+ssh://git@github.com/bigcommerce-labs/form-poster-js.git#01c0b81739169671eff252d64e6e4c56957059ea"
 
 from@~0:
   version "0.1.7"


### PR DESCRIPTION
## What?
* Bump `form-poster-js` to `v1.1.1`.

## Why?
* To fix [callback getting called prematurely](https://github.com/bigcommerce-labs/form-poster-js/pull/3).

## Testing / Proof
* Unit

ping @bigcommerce-labs/checkout @bigcommerce-labs/payments 
