### PR TITLE
fix(store): PAYMENTS-1983 Inject 'storeRequestSender' in the correct position as per the method signature

### DIFF
--- a/src/client/client.js
+++ b/src/client/client.js
@@ -1,6 +1,7 @@
 import objectAssign from 'object-assign';
 import OffsitePaymentInitializer from '../payment/offsite-payment-initializer';
 import PaymentSubmitter from '../payment/payment-submitter';
+import ClientTokenGenerator from '../payment/client-token-generator';
 import StoreRequestSender from '../store/store-request-sender';
 import DEFAULT_CONFIG from './default-config';
 
@@ -13,12 +14,14 @@ export default class Client {
         const clientConfig = objectAssign({}, DEFAULT_CONFIG, config);
         const offsitePaymentInitializer = OffsitePaymentInitializer.create(clientConfig);
         const paymentSubmitter = PaymentSubmitter.create(clientConfig);
+        const clientTokenGenerator = ClientTokenGenerator.create(clientConfig);
         const storeRequestSender = StoreRequestSender.create(clientConfig);
 
         return new Client(
             clientConfig,
             paymentSubmitter,
             offsitePaymentInitializer,
+            clientTokenGenerator,
             storeRequestSender
         );
     }


### PR DESCRIPTION
## What?
Injects the `storeRequestSender` at the correct position of the Client class. 

## Why?
The Client class currently expects the following parameters:

``` javascript
/**
 * @param {Object} config
 * @param {PaymentSubmitter} paymentSubmitter
 * @param {OffsitePaymentInitializer} offsitePaymentInitializer
 * @param {ClientTokenGenerator} clientTokenGenerator
 * @param {StoreRequestSender} storeRequestSender
 */
```

The `ClientTokenGenerator` is expected but unused.

## Testing / Proof
Unit tests
Coverage 100%

ping @davidchin @supercrabtree  @bigcommerce-labs/payments 
