### PR TITLE
feat(payment): PAYMENTS-1990 Map vault data to payload

### DIFF
--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -90,6 +90,7 @@
  * @property {string} ccName
  * @property {string} ccNumber
  * @property {?boolean} shouldSaveInstrument
+ * @property {?string} instrumentId
  */
 
 /**

--- a/test/mocks/payment-request-data.js
+++ b/test/mocks/payment-request-data.js
@@ -103,7 +103,7 @@ const paymentRequestDataMock = {
         ccName: 'Foo Bar',
         ccNumber: '4007000000027',
         ccCustomerCode: 'XYZ',
-        shouldSaveInstrument: true,
+        shouldSaveInstrument: false,
     },
     paymentMethod: {
         id: 'paypalprous',

--- a/test/payment/v1/payment-mappers/payment-mapper.spec.js
+++ b/test/payment/v1/payment-mappers/payment-mapper.spec.js
@@ -71,6 +71,52 @@ describe('PaymentMapper', () => {
         });
     });
 
+    it('maps vaulting data to the payload', () => {
+        data = merge({}, data, {
+            payment: {
+                shouldSaveInstrument: true,
+                instrumentId: 'token1',
+                ccCvv: '123',
+            },
+        });
+
+        const output = paymentMapper.mapToPayment(data);
+
+        expect(output.vault_payment_instrument).toBeUndefined();
+        expect(output).toEqual(
+            jasmine.objectContaining({
+                device: {
+                    fingerprint_id: data.orderMeta.deviceFingerprint,
+                },
+                device_info: data.quoteMeta.request.deviceSessionId,
+                gateway: data.paymentMethod.id,
+                notify_url: data.order.callbackUrl,
+                return_url: data.paymentMethod.returnUrl,
+                bigpay_token: {
+                    token: data.payment.instrumentId,
+                    verification_value: data.payment.ccCvv,
+                },
+            })
+        );
+    });
+
+    it('maps requests for instrument to be vaulted', () => {
+        data = merge({}, data, {
+            payment: {
+                shouldSaveInstrument: true,
+            },
+        });
+
+        const output = paymentMapper.mapToPayment(data);
+
+        expect(output.bigpay_token).toBeUndefined();
+        expect(output).toEqual(
+            jasmine.objectContaining({
+                vault_payment_instrument: data.payment.shouldSaveInstrument,
+            })
+        );
+    });
+
     it('maps the input object into a payment object with method', () => {
         data = merge({}, data, {
             payment: {


### PR DESCRIPTION
## What?
Defined mappings to enable the use of a vaulted card

```javascript
vault_access_token: payment.vaultAccessToken,
bigpay_instrument_token: payment.instrumentToken,
```

- If a vaulted card is supplied omit the `vault_payment_instrument` property

## Why?
To allow users to checkout with vaulted card

## Testing / Proof
Unit tests

ping @bigcommerce-labs/payments @bigcommerce-labs/checkout @wedy @cwalsh @davidchin 
