### PR TITLE
refactor(payment): PAYMENTS-1990 Remove unused shopperToken

### DIFF
--- a/src/client/client.js
+++ b/src/client/client.js
@@ -105,17 +105,6 @@ export default class Client {
      * @param {Function} [callback]
      * @return {void}
      */
-    getShopperToken(data, callback) {
-        this.storeRequestSender.getShopperToken(data, callback);
-    }
-
-    /**
-     * @param {Object} data
-     * @param {string} data.storeId
-     * @param {string} data.shopperId
-     * @param {Function} [callback]
-     * @return {void}
-     */
     getShopperInstruments(data, callback) {
         this.storeRequestSender.getShopperInstruments(data, callback);
     }

--- a/src/store/store-request-sender.js
+++ b/src/store/store-request-sender.js
@@ -39,20 +39,6 @@ export default class StoreRequestSender {
      * @param {Function} [callback]
      * @return {void}
      */
-    getShopperToken(data, callback) {
-        const url = this.urlHelper.getTokenUrl(data.storeId, data.shopperId);
-        const options = {
-            headers: mapToHeaders(data),
-        };
-
-        this.requestSender.postRequest(url, null, options, callback);
-    }
-
-    /**
-     * @param {Object} data
-     * @param {Function} [callback]
-     * @return {void}
-     */
     getShopperInstruments(data, callback) {
         const url = this.urlHelper.getInstrumentsUrl(data.storeId, data.shopperId);
         const options = {

--- a/src/store/url-helper.js
+++ b/src/store/url-helper.js
@@ -26,15 +26,6 @@ export default class UrlHelper {
      * @param {number} shopperId
      * @returns {string}
      */
-    getTokenUrl(storeId, shopperId) {
-        return `${this.host}/api/v2/stores/${storeId}/shoppers/${shopperId}/tokens`;
-    }
-
-    /**
-     * @param {number} storeId
-     * @param {number} shopperId
-     * @returns {string}
-     */
     getInstrumentsUrl(storeId, shopperId) {
         return `${this.host}/api/v2/stores/${storeId}/shoppers/${shopperId}/instruments`;
     }

--- a/test/client/client.spec.js
+++ b/test/client/client.spec.js
@@ -80,16 +80,7 @@ describe('Client', () => {
         expect(clientTokenGenerator.generateClientToken).toHaveBeenCalledWith(data, callback);
     });
 
-    it('requests a shopper token', () => {
-        const callback = () => {};
-        const data = storeIntrumentDataMock;
-
-        client.getShopperToken(data, callback);
-
-        expect(storeRequestSender.getShopperToken).toHaveBeenCalledWith(data, callback);
-    });
-
-    it('requests a shopper token', () => {
+    it('request a shopper\'s instruments', () => {
         const callback = () => {};
         const data = storeIntrumentDataMock;
 
@@ -98,7 +89,7 @@ describe('Client', () => {
         expect(storeRequestSender.getShopperInstruments).toHaveBeenCalledWith(data, callback);
     });
 
-    it('generates a client token', () => {
+    it('posts a new instrument', () => {
         const callback = () => {};
         const data = storeIntrumentDataMock;
 
@@ -107,7 +98,7 @@ describe('Client', () => {
         expect(storeRequestSender.postShopperInstrument).toHaveBeenCalledWith(data, callback);
     });
 
-    it('generates a client token', () => {
+    it('deletes an instrument', () => {
         const callback = () => {};
         const data = storeIntrumentDataMock;
 

--- a/test/store/store-request-sender.spec.js
+++ b/test/store/store-request-sender.spec.js
@@ -35,14 +35,6 @@ describe('StoreRequestSender', () => {
         expect(instance instanceof StoreRequestSender).toBeTruthy();
     });
 
-    it('requests a shopper token with the appropriately mapped headers', () => {
-        storeRequestSender.getShopperToken(data, () => {});
-
-        expect(urlHelperMock.getTokenUrl).toHaveBeenCalledWith(data.storeId, data.shopperId);
-        expect(requestSenderMock.postRequest).toHaveBeenCalled();
-        expect(mappers.mapToHeaders).toHaveBeenCalled();
-    });
-
     it('request a shopper instrument with the appropriately mapped headers', () => {
         storeRequestSender.getShopperInstruments(data, () => {});
 

--- a/test/store/url-helper.spec.js
+++ b/test/store/url-helper.spec.js
@@ -18,13 +18,6 @@ describe('UrlHelper', () => {
         expect(instance instanceof UrlHelper).toBeTruthy();
     });
 
-    it('returns a URL for submitting payments to an API provider', () => {
-        const result = urlHelper.getTokenUrl(storeId, shopperId);
-        const expected = `${host}/api/v2/stores/${storeId}/shoppers/${shopperId}/tokens`;
-
-        expect(result).toEqual(expected);
-    });
-
     it('returns a URL for submitting payments to an offsite provider', () => {
         const result = urlHelper.getInstrumentsUrl(storeId, shopperId);
         const expected = `${host}/api/v2/stores/${storeId}/shoppers/${shopperId}/instruments`;


### PR DESCRIPTION
## What?
Removes unused shopper token function.

## Why?
Because we need to request the shopper token via BcApp, not BigPay. 
This logic will likely be placed in the checkout-sdk

## Testing / Proof
- Unit tests

ping @bigcommerce-labs/payments @davidchin @icatalina @supercrabtree @filakhtov 
