### PR TITLE
chore(common): CHECKOUT-2959 Bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "deep-assign": "^2.0.0",
-    "@bigcommerce/form-poster": "git+ssh://git@github.com/bigcommerce/form-poster-js.git#1.1.1",
+    "@bigcommerce/form-poster": "git+ssh://git@github.com/bigcommerce/form-poster-js.git#1.1.2",
     "object-assign": "^4.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@bigcommerce/form-poster@git+ssh://git@github.com/bigcommerce/form-poster-js.git#1.1.1":
-  version "1.1.1"
-  resolved "git+ssh://git@github.com/bigcommerce/form-poster-js.git#01c0b81739169671eff252d64e6e4c56957059ea"
+"@bigcommerce/form-poster@git+ssh://git@github.com/bigcommerce/form-poster-js.git#1.1.2":
+  version "1.1.2"
+  resolved "git+ssh://git@github.com/bigcommerce/form-poster-js.git#0d0c14290df3fdbe8432935a99a0c6da648cd72f"
 
 JSONStream@^1.0.4:
   version "1.3.1"


### PR DESCRIPTION
Bump dependency as dependency changed but tag was the same, and cause caching issues.