### PR TITLE
CHECKOUT-3035 Provide config setter

### DIFF
--- a/src/client/client.js
+++ b/src/client/client.js
@@ -71,6 +71,10 @@ export default class Client {
         this.storeRequestSender = storeRequestSender;
     }
 
+    setHost(host) {
+        this.config.host = host;
+    }
+
     /**
      * @param {PaymentRequestData} data
      * @param {Function} [callback]

--- a/src/payment/url-helper.js
+++ b/src/payment/url-helper.js
@@ -13,12 +13,20 @@ export default class UrlHelper {
      * @param {string} config.host
      * @returns {void}
      */
-    constructor({ host }) {
+    constructor(config) {
         /**
          * @private
-         * @type {string}
+         * @type {Object}
          */
-        this.host = host;
+        this.config = config;
+    }
+
+    /**
+     * @private
+     * @returns {string}
+     */
+    get host() {
+        return this.config.host;
     }
 
     /**


### PR DESCRIPTION
## What?
Provide a config setter

## Why?
Because we need to provide an instance statically in Checkout SDK, however we need to intialize the config objects with an async call.