### PR TITLE
feat(store): PAYMENTS-2672 Allow consumers to post a trusted shipping address

### DIFF
--- a/src/client/client.js
+++ b/src/client/client.js
@@ -113,6 +113,18 @@ export default class Client {
      * @param {Object} data
      * @param {string} data.storeId
      * @param {string} data.shopperId
+     * @param {AddressData} data.shippingAddress
+     * @param {Function} [callback]
+     * @return {void}
+     */
+    postTrustedShippingAddress(data, callback) {
+        this.storeRequestSender.postTrustedShippingAddress(data, callback);
+    }
+
+    /**
+     * @param {Object} data
+     * @param {string} data.storeId
+     * @param {string} data.shopperId
      * @param {CreditCard} data.creditCard
      * @param {AddressData} data.billingAddress
      * @param {boolean} data.defaultInstrument

--- a/src/store/store-request-sender.js
+++ b/src/store/store-request-sender.js
@@ -1,7 +1,11 @@
 import RequestSender from '../common/http-request/request-sender';
-import { DELETE } from '../common/http-request/method-types';
+import { DELETE, POST } from '../common/http-request/method-types';
 import UrlHelper from './url-helper';
-import { mapToHeaders, mapToInstrumentPayload } from './v2/mappers';
+import {
+    mapToHeaders,
+    mapToInstrumentPayload,
+    mapToTrustedShippingAddressPayload,
+} from './v2/mappers';
 
 export default class StoreRequestSender {
     /**
@@ -46,6 +50,22 @@ export default class StoreRequestSender {
         };
 
         this.requestSender.sendRequest(url, null, options, callback);
+    }
+
+    /**
+     * @param {Object} data
+     * @param {Function} [callback]
+     * @return {void}
+     */
+    postTrustedShippingAddress(data, callback) {
+        const url = this.urlHelper.getTrustedShippingAddressUrl(data.storeId, data.shopperId);
+        const payload = mapToTrustedShippingAddressPayload(data);
+        const options = {
+            method: POST,
+            headers: mapToHeaders(data),
+        };
+
+        this.requestSender.postRequest(url, payload, options, callback);
     }
 
     /**

--- a/src/store/url-helper.js
+++ b/src/store/url-helper.js
@@ -33,6 +33,15 @@ export default class UrlHelper {
     /**
      * @param {number} storeId
      * @param {number} shopperId
+     * @return {string}
+     */
+    getTrustedShippingAddressUrl(storeId, shopperId) {
+        return `${this.host}/api/v2/stores/${storeId}/shoppers/${shopperId}/instruments/trusted_shipping_address`;
+    }
+
+    /**
+     * @param {number} storeId
+     * @param {number} shopperId
      * @param {number} instrumentId
      * @returns {string}
      */

--- a/src/store/v2/mappers/index.js
+++ b/src/store/v2/mappers/index.js
@@ -19,8 +19,19 @@ export function mapToInstrumentPayload(data = {}) {
     return omitNil({
         provider,
         credit_card: mapToCreditCard(data),
-        billing_address: mapToAddress(data),
+        billing_address: mapToAddress(data.billingAddress),
         default_instrument,
+    });
+}
+
+/**
+ * @param {Object} [data={}]
+ * @param {Object} data.shippingAddress
+ * @return {Object}
+ */
+export function mapToTrustedShippingAddressPayload(data = {}) {
+    return omitNil({
+        shipping_address: mapToAddress(data.shippingAddress),
     });
 }
 
@@ -36,23 +47,23 @@ export function mapToHeaders({ authToken: Authorization } = {}) {
 }
 
 /**
- * @param {AddressData} data
+ * @param {AddressData} address
  * @return {Object}
  */
-function mapToAddress({ billingAddress = {} }) {
-    const state = mapToState(billingAddress.provinceCode, billingAddress.province);
+function mapToAddress(address = {}) {
+    const state = mapToState(address.provinceCode, address.province);
 
     return omitNil({
-        address_line_1: billingAddress.addressLine1,
-        address_line_2: billingAddress.addressLine2,
-        city: billingAddress.city,
-        company: billingAddress.company,
-        country_code: billingAddress.countryCode,
-        email: billingAddress.email,
-        first_name: billingAddress.firstName,
-        last_name: billingAddress.lastName,
-        phone: billingAddress.phone,
-        postal_code: billingAddress.postCode,
+        address_line_1: address.addressLine1,
+        address_line_2: address.addressLine2,
+        city: address.city,
+        company: address.company,
+        country_code: address.countryCode,
+        email: address.email,
+        first_name: address.firstName,
+        last_name: address.lastName,
+        phone: address.phone,
+        postal_code: address.postCode,
         state,
     });
 }

--- a/test/client/client.spec.js
+++ b/test/client/client.spec.js
@@ -2,7 +2,7 @@ import merge from 'lodash/merge';
 import { HOSTED } from '../../src/payment/payment-types';
 import Client from '../../src/client/client';
 import paymentRequestDataMock from '../mocks/payment-request-data';
-import storeIntrumentDataMock from '../mocks/store-instrument-data';
+import { storeIntrumentDataMock, trustedShippingAddressDataMock } from '../mocks/store-instrument-data';
 
 describe('Client', () => {
     let client;
@@ -30,6 +30,7 @@ describe('Client', () => {
         storeRequestSender = {
             getShopperToken: jasmine.createSpy('getShopperToken'),
             getShopperInstruments: jasmine.createSpy('getShopperInstruments'),
+            postTrustedShippingAddress: jasmine.createSpy('postTrustedShippingAddress'),
             postShopperInstrument: jasmine.createSpy('postShopperInstrument'),
             deleteShopperInstrument: jasmine.createSpy('deleteShopperInstrument'),
         };
@@ -87,6 +88,15 @@ describe('Client', () => {
         client.getShopperInstruments(data, callback);
 
         expect(storeRequestSender.getShopperInstruments).toHaveBeenCalledWith(data, callback);
+    });
+
+    it('posts a trusted shipping address', () => {
+        const callback = () => {};
+        const data = trustedShippingAddressDataMock;
+
+        client.postTrustedShippingAddress(data, callback);
+
+        expect(storeRequestSender.postTrustedShippingAddress).toHaveBeenCalledWith(data, callback);
     });
 
     it('posts a new instrument', () => {

--- a/test/mocks/store-instrument-data.js
+++ b/test/mocks/store-instrument-data.js
@@ -46,3 +46,22 @@ export const instrumentRequestDataMock = {
     },
     defaultInstrument: true,
 };
+
+export const trustedShippingAddressDataMock = {
+    storeId: '123',
+    shopperId: '321',
+    shippingAddress: {
+        addressLine1: '1-3 Smail St',
+        addressLine2: 'Ultimo',
+        city: 'Sydney',
+        company: 'BigCommerce',
+        countryCode: 'AU',
+        email: 'shopper@bigcommerce.com',
+        firstName: 'John',
+        lastName: 'Doe',
+        phone: '98765432',
+        postCode: '2007',
+        provinceCode: 'NSW',
+        province: 'New South Wales',
+    },
+};

--- a/test/store/store-request-sender.spec.js
+++ b/test/store/store-request-sender.spec.js
@@ -13,11 +13,13 @@ describe('StoreRequestSender', () => {
 
         spyOn(mappers, 'mapToHeaders');
         spyOn(mappers, 'mapToInstrumentPayload');
+        spyOn(mappers, 'mapToTrustedShippingAddressPayload');
 
         urlHelperMock = {
             getTokenUrl: jasmine.createSpy('getTokenUrl').and.callThrough(),
             getInstrumentsUrl: jasmine.createSpy('getInstrumentsUrl').and.callThrough(),
             getInstrumentByIdUrl: jasmine.createSpy('getInstrumentByIdUrl').and.callThrough(),
+            getTrustedShippingAddressUrl: jasmine.createSpy('getTrustedShippingAddressUrl').and.callThrough(),
         };
 
         requestSenderMock = {
@@ -41,6 +43,15 @@ describe('StoreRequestSender', () => {
         expect(urlHelperMock.getInstrumentsUrl).toHaveBeenCalledWith(data.storeId, data.shopperId);
         expect(requestSenderMock.sendRequest).toHaveBeenCalled();
         expect(mappers.mapToHeaders).toHaveBeenCalled();
+    });
+
+    it('posts a trusted shipping address with the appropriately mapped headers and payload', () => {
+        storeRequestSender.postTrustedShippingAddress(data, () => {});
+
+        expect(urlHelperMock.getTrustedShippingAddressUrl).toHaveBeenCalledWith(data.storeId, data.shopperId);
+        expect(requestSenderMock.postRequest).toHaveBeenCalled();
+        expect(mappers.mapToHeaders).toHaveBeenCalled();
+        expect(mappers.mapToTrustedShippingAddressPayload).toHaveBeenCalled();
     });
 
     it('posts a new shopper instrument with the appropriately mapped headers and payload', () => {

--- a/test/store/url-helper.spec.js
+++ b/test/store/url-helper.spec.js
@@ -25,6 +25,13 @@ describe('UrlHelper', () => {
         expect(result).toEqual(expected);
     });
 
+    it('returns a URL for posting a trusted shipping address', () => {
+        const result = urlHelper.getTrustedShippingAddressUrl(storeId, shopperId);
+        const expected = `${host}/api/v2/stores/${storeId}/shoppers/${shopperId}/instruments/trusted_shipping_address`;
+
+        expect(result).toEqual(expected);
+    });
+
     it('returns a URL for generating a client token', () => {
         const result = urlHelper.getInstrumentByIdUrl(storeId, shopperId, instrumentId);
         const expected = `${host}/api/v2/stores/${storeId}/shoppers/${shopperId}/instruments/${instrumentId}`;

--- a/test/store/v2/mappers/index.spec.js
+++ b/test/store/v2/mappers/index.spec.js
@@ -1,5 +1,13 @@
-import { mapToInstrumentPayload, mapToHeaders } from '../../../../src/store/v2/mappers';
-import { instrumentRequestDataMock, authTokenMock } from '../../../mocks/store-instrument-data';
+import {
+    authTokenMock,
+    instrumentRequestDataMock,
+    trustedShippingAddressDataMock,
+} from '../../../mocks/store-instrument-data';
+import {
+    mapToInstrumentPayload,
+    mapToHeaders,
+    mapToTrustedShippingAddressPayload,
+} from '../../../../src/store/v2/mappers';
 
 describe('StoreMapper', () => {
     let headerData;
@@ -73,6 +81,43 @@ describe('StoreMapper', () => {
             },
             default_instrument: defaultInstrument,
         });
+
+        expect(result).toEqual(expected);
+    });
+
+    it('maps the input object into a trusted shipping address object', () => {
+        const { shippingAddress } = trustedShippingAddressDataMock;
+
+        const result = mapToTrustedShippingAddressPayload(trustedShippingAddressDataMock);
+        const expected = jasmine.objectContaining({
+            shipping_address: {
+                address_line_1: shippingAddress.addressLine1,
+                address_line_2: shippingAddress.addressLine2,
+                city: shippingAddress.city,
+                company: shippingAddress.company,
+                country_code: shippingAddress.countryCode,
+                email: shippingAddress.email,
+                first_name: shippingAddress.firstName,
+                last_name: shippingAddress.lastName,
+                phone: shippingAddress.phone,
+                postal_code: shippingAddress.postCode,
+                state: {
+                    code: shippingAddress.provinceCode,
+                    name: shippingAddress.province,
+                },
+            },
+        });
+
+        expect(result).toEqual(expected);
+    });
+
+    it('accepts null and returns an empty shipping address object', () => {
+        const result = mapToTrustedShippingAddressPayload();
+        const expected = {
+            shipping_address: {
+                state: {},
+            },
+        };
 
         expect(result).toEqual(expected);
     });


### PR DESCRIPTION
## What?
Adds the ability to Post a trusted shipping address and retrieve a list of instruments.

[Bigpay API](https://github.com/bigcommerce/api-schema/blob/master/bigpay/v2/docs/payments.yaml)

## Why?
Allow a shipper to checkout with a stored credit card and avoid providing a cvv if the shipping address is 'trusted'.

## Testing / Proof
<img width="679" alt="screen shot 2018-04-10 at 10 01 51 am" src="https://user-images.githubusercontent.com/3030010/38529164-8d9887bc-3ca6-11e8-9bad-381885ac5d4b.png">

ping @davidchin @supercrabtree @bigcommerce/payments 