### PR TITLE
fix(store): PAYMENTS-2122 Ensure config reference is not lost when host is updated

### DIFF
--- a/src/client/client.js
+++ b/src/client/client.js
@@ -71,6 +71,10 @@ export default class Client {
         this.storeRequestSender = storeRequestSender;
     }
 
+    /**
+     * @param {string} host
+     * @returns {void}
+     */
     setHost(host) {
         this.config.host = host;
     }

--- a/src/store/url-helper.js
+++ b/src/store/url-helper.js
@@ -13,12 +13,25 @@ export default class UrlHelper {
      * @param {string} config.host
      * @returns {void}
      */
-    constructor({ host }) {
+    constructor(config) {
         /**
          * @private
-         * @type {string}
+         * @type {Object}
          */
-        this.host = host;
+        this.config = config;
+    }
+
+    /**
+     * @private
+     * @returns {string}
+     * @throws {Error}
+     */
+    get host() {
+        if (!this.config || !this.config.host) {
+            throw new Error('Host URL unavailable or not supplied.');
+        }
+
+        return this.config.host;
     }
 
     /**

--- a/test/client/client.spec.js
+++ b/test/client/client.spec.js
@@ -43,6 +43,16 @@ describe('Client', () => {
         );
     });
 
+    it('sets the host url after client creation', () => {
+        const hostUrl = 'https://google.com';
+
+        expect(client.config.host).toEqual(config.host);
+
+        client.setHost(hostUrl);
+
+        expect(client.config.host).toEqual(hostUrl);
+    });
+
     it('returns an instance of Client', () => {
         const instance = Client.create();
 

--- a/test/store/url-helper.spec.js
+++ b/test/store/url-helper.spec.js
@@ -18,6 +18,20 @@ describe('UrlHelper', () => {
         expect(instance instanceof UrlHelper).toBeTruthy();
     });
 
+    it('returns the correct host url', () => {
+        expect(urlHelper.host).toBe('https://bigpay.com');
+    });
+
+    it('throws an error if host was not supplied', () => {
+        urlHelper = new UrlHelper();
+
+        expect(() => urlHelper.host).toThrow();
+
+        urlHelper = new UrlHelper({});
+
+        expect(() => urlHelper.host).toThrow();
+    });
+
     it('returns a URL for submitting payments to an offsite provider', () => {
         const result = urlHelper.getInstrumentsUrl(storeId, shopperId);
         const expected = `${host}/api/v2/stores/${storeId}/shoppers/${shopperId}/instruments`;


### PR DESCRIPTION
## What?
Access the config via the config object, which is reliant on the object reference.

## Why?
The new `setHost` function updates the config post initialisation. This is problematic because we destructure the config like so `function foo({ host })` and lose the reference to `config` in the process. 

## Testing / Proof
Unit

ping @bigcommerce/payments @bigcommerce/checkout 
