### PR TITLE
feat(payments): INT-275 Add a mapper for Cryptogram Payment instrument

### DIFF
--- a/src/payment/v1/payment-mappers/payment-mapper.js
+++ b/src/payment/v1/payment-mappers/payment-mapper.js
@@ -65,6 +65,10 @@ export default class PaymentMapper {
                     token: nonce,
                 },
             });
+        } else if (payment.cryptogramId) {
+            objectAssign(payload, {
+                credit_card_cryptogram: this.mapToCryptogram(data),
+            });
         } else {
             objectAssign(payload, {
                 credit_card: this.mapToCreditCard(data),
@@ -108,6 +112,22 @@ export default class PaymentMapper {
         return omitNil({
             token: payment.instrumentId,
             verification_value: payment.ccCvv,
+        });
+    }
+
+    /**
+     * @private
+     * @param {PaymentRequestData} data
+     * @return {Object}
+     */
+    mapToCryptogram({ payment }) {
+        return omitNil({
+            payment_cryptogram: payment.cryptogramId,
+            eci: payment.eci,
+            xid: payment.transactionId,
+            month: payment.ccExpiry ? toNumber(payment.ccExpiry.month) : null,
+            number: payment.ccNumber,
+            year: payment.ccExpiry ? toNumber(payment.ccExpiry.year) : null,
         });
     }
 }

--- a/test/payment/v1/payment-mappers/payment-mapper.spec.js
+++ b/test/payment/v1/payment-mappers/payment-mapper.spec.js
@@ -74,6 +74,72 @@ describe('PaymentMapper', () => {
         });
     });
 
+    it('maps the input object into a payment object with cryptogram', () => {
+        data = merge({}, data, {
+            payment: {
+                cryptogramId: 'cryptogram123',
+                eci: 'eci123',
+                transactionId: 'transaction123',
+            },
+        });
+
+        const output = paymentMapper.mapToPayment(data);
+
+        expect(output.cryptogramId).toBeUndefined();
+        expect(output).toEqual(
+            jasmine.objectContaining({
+                device: {
+                    fingerprint_id: data.orderMeta.deviceFingerprint,
+                },
+                device_info: data.quoteMeta.request.deviceSessionId,
+                gateway: data.paymentMethod.id,
+                notify_url: data.order.callbackUrl,
+                return_url: data.paymentMethod.returnUrl,
+                credit_card_cryptogram: {
+                    payment_cryptogram: data.payment.cryptogramId,
+                    eci: data.payment.eci,
+                    xid: data.payment.transactionId,
+                    number: data.payment.ccNumber,
+                    month: parseInt(data.payment.ccExpiry.month, 10),
+                    year: parseInt(data.payment.ccExpiry.year, 10),
+                },
+            })
+        );
+    });
+
+    it('maps the input object into a payment object with cryptogram without expiration', () => {
+        data = merge({}, data, {
+            payment: {
+                cryptogramId: 'cryptogram123',
+                eci: 'eci123',
+                transactionId: 'transaction123',
+                ccNumber: 'aa',
+                ccExpiry: null,
+            },
+        });
+
+        const output = paymentMapper.mapToPayment(data);
+
+        expect(output.cryptogramId).toBeUndefined();
+        expect(output).toEqual(
+            jasmine.objectContaining({
+                device: {
+                    fingerprint_id: data.orderMeta.deviceFingerprint,
+                },
+                device_info: data.quoteMeta.request.deviceSessionId,
+                gateway: data.paymentMethod.id,
+                notify_url: data.order.callbackUrl,
+                return_url: data.paymentMethod.returnUrl,
+                credit_card_cryptogram: {
+                    payment_cryptogram: data.payment.cryptogramId,
+                    eci: data.payment.eci,
+                    xid: data.payment.transactionId,
+                    number: data.payment.ccNumber,
+                },
+            })
+        );
+    });
+
     it('maps vaulting data to the payload', () => {
         data = merge({}, data, {
             payment: {


### PR DESCRIPTION
## What?
Add a mapper to send the data to big pay with the structure that chasepay needs.

## Why?
We need to send the data with a different structure that isn't supported by the mapper that already exist.

## Testing / Proof

<img width="551" alt="screen shot 2018-05-14 at 5 33 06 pm" src="https://user-images.githubusercontent.com/38794472/40026891-ed7a3bec-579c-11e8-9a9a-cc4918b45dde.png">
<img width="671" alt="screen shot 2018-05-14 at 5 32 52 pm" src="https://user-images.githubusercontent.com/38794472/40026893-f1970994-579c-11e8-8627-2e331318ee5d.png">

NOTE: This PR has a dependency with https://github.com/rodna-bc/checkout-sdk-js/tree/INT-275 of @rodna-bc 

@bigcommerce/payments  @bigcommerce/checkout 
