### PR TITLE
refactor(client): PAYMENTS-2672 Rename vaulting endpoints

### DIFF
--- a/src/client/client.js
+++ b/src/client/client.js
@@ -113,8 +113,8 @@ export default class Client {
      * @param {Function} [callback]
      * @return {void}
      */
-    getShopperInstruments(data, callback) {
-        this.storeRequestSender.getShopperInstruments(data, callback);
+    loadInstruments(data, callback) {
+        this.storeRequestSender.loadInstruments(data, callback);
     }
 
     /**
@@ -125,8 +125,8 @@ export default class Client {
      * @param {Function} [callback]
      * @return {void}
      */
-    postTrustedShippingAddress(data, callback) {
-        this.storeRequestSender.postTrustedShippingAddress(data, callback);
+    loadInstrumentsWithAddress(data, callback) {
+        this.storeRequestSender.loadInstrumentsWithAddress(data, callback);
     }
 
     /**

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -109,7 +109,7 @@ export default class Client {
     /**
      * @param {Object} data
      * @param {string} data.storeId
-     * @param {string} data.shopperId
+     * @param {string} data.customerId
      * @param {Function} [callback]
      * @return {void}
      */
@@ -120,7 +120,7 @@ export default class Client {
     /**
      * @param {Object} data
      * @param {string} data.storeId
-     * @param {string} data.shopperId
+     * @param {string} data.customerId
      * @param {AddressData} data.shippingAddress
      * @param {Function} [callback]
      * @return {void}
@@ -132,7 +132,7 @@ export default class Client {
     /**
      * @param {Object} data
      * @param {string} data.storeId
-     * @param {string} data.shopperId
+     * @param {string} data.customerId
      * @param {CreditCard} data.creditCard
      * @param {AddressData} data.billingAddress
      * @param {boolean} data.defaultInstrument
@@ -147,7 +147,7 @@ export default class Client {
     /**
      * @param {Object} data
      * @param {string} data.storeId
-     * @param {string} data.shopperId
+     * @param {string} data.customerId
      * @param {string} data.instrumentId
      * @param {Function} [callback]
      * @return {void}

--- a/src/store/store-request-sender.js
+++ b/src/store/store-request-sender.js
@@ -43,7 +43,7 @@ export default class StoreRequestSender {
      * @param {Function} [callback]
      * @return {void}
      */
-    getShopperInstruments(data, callback) {
+    loadInstruments(data, callback) {
         const url = this.urlHelper.getInstrumentsUrl(data.storeId, data.shopperId);
         const options = {
             headers: mapToHeaders(data),
@@ -57,7 +57,7 @@ export default class StoreRequestSender {
      * @param {Function} [callback]
      * @return {void}
      */
-    postTrustedShippingAddress(data, callback) {
+    loadInstrumentsWithAddress(data, callback) {
         const url = this.urlHelper.getTrustedShippingAddressUrl(data.storeId, data.shopperId);
         const payload = mapToTrustedShippingAddressPayload(data);
         const options = {

--- a/src/store/store-request-sender.js
+++ b/src/store/store-request-sender.js
@@ -44,7 +44,7 @@ export default class StoreRequestSender {
      * @return {void}
      */
     loadInstruments(data, callback) {
-        const url = this.urlHelper.getInstrumentsUrl(data.storeId, data.shopperId);
+        const url = this.urlHelper.getInstrumentsUrl(data.storeId, data.customerId);
         const options = {
             headers: mapToHeaders(data),
         };
@@ -58,7 +58,7 @@ export default class StoreRequestSender {
      * @return {void}
      */
     loadInstrumentsWithAddress(data, callback) {
-        const url = this.urlHelper.getTrustedShippingAddressUrl(data.storeId, data.shopperId);
+        const url = this.urlHelper.getTrustedShippingAddressUrl(data.storeId, data.customerId);
         const payload = mapToTrustedShippingAddressPayload(data);
         const options = {
             method: POST,
@@ -74,7 +74,7 @@ export default class StoreRequestSender {
      * @return {void}
      */
     postShopperInstrument(data, callback) {
-        const url = this.urlHelper.getInstrumentsUrl(data.storeId, data.shopperId);
+        const url = this.urlHelper.getInstrumentsUrl(data.storeId, data.customerId);
         const payload = mapToInstrumentPayload(data);
         const options = {
             headers: mapToHeaders(data),
@@ -91,7 +91,7 @@ export default class StoreRequestSender {
     deleteShopperInstrument(data, callback) {
         const url = this.urlHelper.getInstrumentByIdUrl(
             data.storeId,
-            data.shopperId,
+            data.customerId,
             data.instrumentId
         );
         const options = {

--- a/src/store/url-helper.js
+++ b/src/store/url-helper.js
@@ -36,29 +36,29 @@ export default class UrlHelper {
 
     /**
      * @param {number} storeId
-     * @param {number} shopperId
+     * @param {number} customerId
      * @returns {string}
      */
-    getInstrumentsUrl(storeId, shopperId) {
-        return `${this.host}/api/v2/stores/${storeId}/shoppers/${shopperId}/instruments`;
+    getInstrumentsUrl(storeId, customerId) {
+        return `${this.host}/api/v2/stores/${storeId}/shoppers/${customerId}/instruments`;
     }
 
     /**
      * @param {number} storeId
-     * @param {number} shopperId
+     * @param {number} customerId
      * @return {string}
      */
-    getTrustedShippingAddressUrl(storeId, shopperId) {
-        return `${this.host}/api/v2/stores/${storeId}/shoppers/${shopperId}/instruments/trusted_shipping_address`;
+    getTrustedShippingAddressUrl(storeId, customerId) {
+        return `${this.host}/api/v2/stores/${storeId}/shoppers/${customerId}/instruments/trusted_shipping_address`;
     }
 
     /**
      * @param {number} storeId
-     * @param {number} shopperId
+     * @param {number} customerId
      * @param {number} instrumentId
      * @returns {string}
      */
-    getInstrumentByIdUrl(storeId, shopperId, instrumentId) {
-        return `${this.host}/api/v2/stores/${storeId}/shoppers/${shopperId}/instruments/${instrumentId}`;
+    getInstrumentByIdUrl(storeId, customerId, instrumentId) {
+        return `${this.host}/api/v2/stores/${storeId}/shoppers/${customerId}/instruments/${instrumentId}`;
     }
 }

--- a/test/client/client.spec.js
+++ b/test/client/client.spec.js
@@ -29,8 +29,8 @@ describe('Client', () => {
 
         storeRequestSender = {
             getShopperToken: jasmine.createSpy('getShopperToken'),
-            getShopperInstruments: jasmine.createSpy('getShopperInstruments'),
-            postTrustedShippingAddress: jasmine.createSpy('postTrustedShippingAddress'),
+            loadInstruments: jasmine.createSpy('loadInstruments'),
+            loadInstrumentsWithAddress: jasmine.createSpy('loadInstrumentsWithAddress'),
             postShopperInstrument: jasmine.createSpy('postShopperInstrument'),
             deleteShopperInstrument: jasmine.createSpy('deleteShopperInstrument'),
         };
@@ -91,22 +91,22 @@ describe('Client', () => {
         expect(clientTokenGenerator.generateClientToken).toHaveBeenCalledWith(data, callback);
     });
 
-    it('request a shopper\'s instruments', () => {
+    it('load instruments', () => {
         const callback = () => {};
         const data = storeIntrumentDataMock;
 
-        client.getShopperInstruments(data, callback);
+        client.loadInstruments(data, callback);
 
-        expect(storeRequestSender.getShopperInstruments).toHaveBeenCalledWith(data, callback);
+        expect(storeRequestSender.loadInstruments).toHaveBeenCalledWith(data, callback);
     });
 
-    it('posts a trusted shipping address', () => {
+    it('load instruments with shipping address', () => {
         const callback = () => {};
         const data = trustedShippingAddressDataMock;
 
-        client.postTrustedShippingAddress(data, callback);
+        client.loadInstrumentsWithAddress(data, callback);
 
-        expect(storeRequestSender.postTrustedShippingAddress).toHaveBeenCalledWith(data, callback);
+        expect(storeRequestSender.loadInstrumentsWithAddress).toHaveBeenCalledWith(data, callback);
     });
 
     it('posts a new instrument', () => {

--- a/test/mocks/store-instrument-data.js
+++ b/test/mocks/store-instrument-data.js
@@ -49,7 +49,7 @@ export const instrumentRequestDataMock = {
 
 export const trustedShippingAddressDataMock = {
     storeId: '123',
-    shopperId: '321',
+    customerId: '321',
     shippingAddress: {
         addressLine1: '1-3 Smail St',
         addressLine2: 'Ultimo',

--- a/test/store/store-request-sender.spec.js
+++ b/test/store/store-request-sender.spec.js
@@ -38,7 +38,7 @@ describe('StoreRequestSender', () => {
     });
 
     it('request a shopper instrument with the appropriately mapped headers', () => {
-        storeRequestSender.getShopperInstruments(data, () => {});
+        storeRequestSender.loadInstruments(data, () => {});
 
         expect(urlHelperMock.getInstrumentsUrl).toHaveBeenCalledWith(data.storeId, data.shopperId);
         expect(requestSenderMock.sendRequest).toHaveBeenCalled();
@@ -46,7 +46,7 @@ describe('StoreRequestSender', () => {
     });
 
     it('posts a trusted shipping address with the appropriately mapped headers and payload', () => {
-        storeRequestSender.postTrustedShippingAddress(data, () => {});
+        storeRequestSender.loadInstrumentsWithAddress(data, () => {});
 
         expect(urlHelperMock.getTrustedShippingAddressUrl).toHaveBeenCalledWith(data.storeId, data.shopperId);
         expect(requestSenderMock.postRequest).toHaveBeenCalled();

--- a/test/store/store-request-sender.spec.js
+++ b/test/store/store-request-sender.spec.js
@@ -40,7 +40,7 @@ describe('StoreRequestSender', () => {
     it('request a shopper instrument with the appropriately mapped headers', () => {
         storeRequestSender.loadInstruments(data, () => {});
 
-        expect(urlHelperMock.getInstrumentsUrl).toHaveBeenCalledWith(data.storeId, data.shopperId);
+        expect(urlHelperMock.getInstrumentsUrl).toHaveBeenCalledWith(data.storeId, data.customerId);
         expect(requestSenderMock.sendRequest).toHaveBeenCalled();
         expect(mappers.mapToHeaders).toHaveBeenCalled();
     });
@@ -48,7 +48,7 @@ describe('StoreRequestSender', () => {
     it('posts a trusted shipping address with the appropriately mapped headers and payload', () => {
         storeRequestSender.loadInstrumentsWithAddress(data, () => {});
 
-        expect(urlHelperMock.getTrustedShippingAddressUrl).toHaveBeenCalledWith(data.storeId, data.shopperId);
+        expect(urlHelperMock.getTrustedShippingAddressUrl).toHaveBeenCalledWith(data.storeId, data.customerId);
         expect(requestSenderMock.postRequest).toHaveBeenCalled();
         expect(mappers.mapToHeaders).toHaveBeenCalled();
         expect(mappers.mapToTrustedShippingAddressPayload).toHaveBeenCalled();
@@ -57,7 +57,7 @@ describe('StoreRequestSender', () => {
     it('posts a new shopper instrument with the appropriately mapped headers and payload', () => {
         storeRequestSender.postShopperInstrument(data, () => {});
 
-        expect(urlHelperMock.getInstrumentsUrl).toHaveBeenCalledWith(data.storeId, data.shopperId);
+        expect(urlHelperMock.getInstrumentsUrl).toHaveBeenCalledWith(data.storeId, data.customerId);
         expect(requestSenderMock.postRequest).toHaveBeenCalled();
         expect(mappers.mapToHeaders).toHaveBeenCalled();
     });
@@ -67,7 +67,7 @@ describe('StoreRequestSender', () => {
 
         expect(urlHelperMock.getInstrumentByIdUrl).toHaveBeenCalledWith(
             data.storeId,
-            data.shopperId,
+            data.customerId,
             data.instrumentId
         );
         expect(requestSenderMock.sendRequest).toHaveBeenCalled();


### PR DESCRIPTION
## What?
Rename the following methods

`getShopperInstruments` -> `loadInstruments`
`postTrustedShippingAddress` -> `loadInstrumentsWithAddress`

## Why?
For clarity and consistency with the sdk 

## Testing / Proof
unit

ping @bigcommerce/payments @bigcommerce/checkout 
