### PR TITLE
feat(payment): PAYMENTS-2675 Add CCNo. as part of the vaulting payment payload

### DIFF
--- a/src/payment/v1/payment-mappers/payment-mapper.js
+++ b/src/payment/v1/payment-mappers/payment-mapper.js
@@ -110,6 +110,7 @@ export default class PaymentMapper {
      */
     mapToBigPayToken({ payment }) {
         return omitNil({
+            credit_card_number_confirmation: payment.ccNumber,
             token: payment.instrumentId,
             verification_value: payment.ccCvv,
         });

--- a/test/payment/v1/payment-mappers/payment-mapper.spec.js
+++ b/test/payment/v1/payment-mappers/payment-mapper.spec.js
@@ -164,6 +164,7 @@ describe('PaymentMapper', () => {
                 bigpay_token: {
                     token: data.payment.instrumentId,
                     verification_value: data.payment.ccCvv,
+                    credit_card_number_confirmation: data.payment.ccNumber,
                 },
             })
         );


### PR DESCRIPTION
## What?
Adds `credit_card_number_confirmation` as part of the vaulting payment payload

## Why?
When a stored credit card is not trusted, we ask the shopper to verify their credit card number.
The card number will then be passed to bigpay along with the bigpay_token and CVV for verification.

## Testing / Proof
Unit

ping @bigcommerce/payments @bigcommerce/checkout 
