### PR TITLE
feat(payment): INT-594 Send ChasePay CheckoutData needed for WePay

### DIFF
--- a/src/payment/v1/payment-mappers/payment-mapper.js
+++ b/src/payment/v1/payment-mappers/payment-mapper.js
@@ -129,6 +129,7 @@ export default class PaymentMapper {
             month: payment.ccExpiry ? toNumber(payment.ccExpiry.month) : null,
             number: payment.ccNumber,
             year: payment.ccExpiry ? toNumber(payment.ccExpiry.year) : null,
+            account_mask: payment.accountMask,
         });
     }
 }

--- a/test/payment/v1/payment-mappers/payment-mapper.spec.js
+++ b/test/payment/v1/payment-mappers/payment-mapper.spec.js
@@ -80,6 +80,7 @@ describe('PaymentMapper', () => {
                 cryptogramId: 'cryptogram123',
                 eci: 'eci123',
                 transactionId: 'transaction123',
+                accountMask: 'accountMask123',
             },
         });
 
@@ -102,6 +103,7 @@ describe('PaymentMapper', () => {
                     number: data.payment.ccNumber,
                     month: parseInt(data.payment.ccExpiry.month, 10),
                     year: parseInt(data.payment.ccExpiry.year, 10),
+                    account_mask: data.payment.accountMask,
                 },
             })
         );
@@ -115,6 +117,7 @@ describe('PaymentMapper', () => {
                 transactionId: 'transaction123',
                 ccNumber: 'aa',
                 ccExpiry: null,
+                accountMask: 'accountMask123',
             },
         });
 
@@ -135,6 +138,7 @@ describe('PaymentMapper', () => {
                     eci: data.payment.eci,
                     xid: data.payment.transactionId,
                     number: data.payment.ccNumber,
+                    account_mask: data.payment.accountMask,
                 },
             })
         );


### PR DESCRIPTION
## What? [INT-594](https://jira.bigcommerce.com/browse/INT-594)
Add accountMask field to mapToCryptogram function.

## Why?
To be able to send accountMask to bigPay.

## Testing / Proof

![image](https://user-images.githubusercontent.com/32551743/41439997-78970c38-6ff2-11e8-9e13-f1d54ccfe332.png)


ping {suggested reviewers}
@bigcommerce/payments 
@bigcommerce/integrations 
