### PR TITLE
fix(payments): PAYMENTS-3064 Use deviceSessionId from payment

### DIFF
--- a/src/payment/v1/payment-mappers/payment-mapper.js
+++ b/src/payment/v1/payment-mappers/payment-mapper.js
@@ -35,11 +35,10 @@ export default class PaymentMapper {
             orderMeta = {},
             payment = {},
             paymentMethod = {},
-            quoteMeta = {},
         } = data;
 
         const payload = {
-            device_info: quoteMeta.request ? quoteMeta.request.deviceSessionId : null,
+            device_info: payment.deviceSessionId ? payment.deviceSessionId : null,
             device: orderMeta.deviceFingerprint ? { fingerprint_id: orderMeta.deviceFingerprint } : null,
             gateway: this.paymentMethodIdMapper.mapToId(paymentMethod),
             notify_url: order.callbackUrl,

--- a/test/mocks/payment-request-data.js
+++ b/test/mocks/payment-request-data.js
@@ -103,6 +103,7 @@ const paymentRequestDataMock = {
         ccName: 'Foo Bar',
         ccNumber: '4007000000027',
         ccCustomerCode: 'XYZ',
+        deviceSessionId: 'fakeDeviceSessionId',
         extraData: { test: 'data' },
         shouldSaveInstrument: false,
     },

--- a/test/payment/v1/payment-mappers/payment-mapper.spec.js
+++ b/test/payment/v1/payment-mappers/payment-mapper.spec.js
@@ -42,7 +42,7 @@ describe('PaymentMapper', () => {
             device: {
                 fingerprint_id: data.orderMeta.deviceFingerprint,
             },
-            device_info: data.quoteMeta.request.deviceSessionId,
+            device_info: data.payment.deviceSessionId,
             gateway: data.paymentMethod.id,
             notify_url: data.order.callbackUrl,
             return_url: data.paymentMethod.returnUrl,
@@ -66,7 +66,7 @@ describe('PaymentMapper', () => {
             device: {
                 fingerprint_id: data.orderMeta.deviceFingerprint,
             },
-            device_info: data.quoteMeta.request.deviceSessionId,
+            device_info: data.payment.deviceSessionId,
             gateway: data.paymentMethod.id,
             notify_url: data.order.callbackUrl,
             return_url: data.paymentMethod.returnUrl,
@@ -92,7 +92,7 @@ describe('PaymentMapper', () => {
                 device: {
                     fingerprint_id: data.orderMeta.deviceFingerprint,
                 },
-                device_info: data.quoteMeta.request.deviceSessionId,
+                device_info: data.payment.deviceSessionId,
                 gateway: data.paymentMethod.id,
                 notify_url: data.order.callbackUrl,
                 return_url: data.paymentMethod.returnUrl,
@@ -129,7 +129,7 @@ describe('PaymentMapper', () => {
                 device: {
                     fingerprint_id: data.orderMeta.deviceFingerprint,
                 },
-                device_info: data.quoteMeta.request.deviceSessionId,
+                device_info: data.payment.deviceSessionId,
                 gateway: data.paymentMethod.id,
                 notify_url: data.order.callbackUrl,
                 return_url: data.paymentMethod.returnUrl,
@@ -161,7 +161,7 @@ describe('PaymentMapper', () => {
                 device: {
                     fingerprint_id: data.orderMeta.deviceFingerprint,
                 },
-                device_info: data.quoteMeta.request.deviceSessionId,
+                device_info: data.payment.deviceSessionId,
                 gateway: data.paymentMethod.id,
                 notify_url: data.order.callbackUrl,
                 return_url: data.paymentMethod.returnUrl,


### PR DESCRIPTION
## What?
- Look at payment form `checkout-sdk` for `deviceSessionId` 

## Why?
- `quoteMeta` has been removed

## Testing / Proof
Updated tests, now passing :) 

ping @bigcommerce/payments @icatalina 
