### PR TITLE
refactor(payment): INT-491 re-map wepay risk token into device_info f…

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ export default function getPaymentData() {
             ccName: 'Foo Bar',
             ccNumber: '4007000000027',
             ccCustomerCode: 'XYZ',
-            extraData: { ... },
         },
         paymentMethod: {
             id: 'paypalprous',

--- a/src/payment/v1/payment-mappers/payment-mapper.js
+++ b/src/payment/v1/payment-mappers/payment-mapper.js
@@ -85,21 +85,14 @@ export default class PaymentMapper {
     mapToCreditCard(data) {
         const { payment = {} } = data;
 
-        const mappedData = {
+        return omitNil({
             account_name: payment.ccName,
             month: payment.ccExpiry ? toNumber(payment.ccExpiry.month) : null,
             number: payment.ccNumber,
             verification_value: payment.ccCvv,
             year: payment.ccExpiry ? toNumber(payment.ccExpiry.year) : null,
             customer_code: payment.ccCustomerCode,
-        };
-
-        if (payment.extraData) {
-            mappedData.extra_data = {};
-            mappedData.extra_data.risk_token = payment.extraData.riskToken;
-        }
-
-        return omitNil(mappedData);
+        });
     }
 
     /**

--- a/test/mocks/payment-request-data.js
+++ b/test/mocks/payment-request-data.js
@@ -104,7 +104,6 @@ const paymentRequestDataMock = {
         ccNumber: '4007000000027',
         ccCustomerCode: 'XYZ',
         deviceSessionId: 'fakeDeviceSessionId',
-        extraData: { test: 'data' },
         shouldSaveInstrument: false,
     },
     paymentMethod: {

--- a/test/payment/v1/payment-mappers/payment-mapper.spec.js
+++ b/test/payment/v1/payment-mappers/payment-mapper.spec.js
@@ -35,9 +35,6 @@ describe('PaymentMapper', () => {
                 verification_value: data.payment.ccCvv,
                 year: parseInt(data.payment.ccExpiry.year, 10),
                 customer_code: data.payment.ccCustomerCode,
-                extra_data: {
-                    risk_token: data.payment.extraData.riskToken,
-                },
             },
             device: {
                 fingerprint_id: data.orderMeta.deviceFingerprint,


### PR DESCRIPTION
[INT-490](https://jira.bigcommerce.com/browse/INT-758INT-490)

## Sibling PR's
[bigpay](https://github.com/bigcommerce/bigpay/pull/1260#pullrequestreview-139125977)
[bigpay-client-js](https://github.com/bigcommerce/bigpay-client-js/pull/71)
[checkout-skd-js](https://github.com/bigcommerce/checkout-sdk-js/pull/343)

## What?
Remove usage of extra_data field so bigpay can reuse device_info field instead

## Why?
Clean up handling of wepay risk token to reuse preexisting deviceSessionId (maps to device_info) field for uniformity

## Testing / Proof
Able to successfully submit orders using device_info field
![image](https://user-images.githubusercontent.com/19637426/42898968-445cfa7e-8a8a-11e8-95d5-6d94cfa5f3a2.png)

ping @bigcommerce/integrations  
