### PR TITLE
feat(store): PAYMENTS-3279 load instruments to accept multiple shipping addresses

### DIFF
--- a/src/client/client.js
+++ b/src/client/client.js
@@ -121,12 +121,12 @@ export default class Client {
      * @param {Object} data
      * @param {string} data.storeId
      * @param {string} data.customerId
-     * @param {AddressData} data.shippingAddress
+     * @param {AddressData[]} data.shippingAddresses
      * @param {Function} [callback]
      * @return {void}
      */
-    loadInstrumentsWithAddress(data, callback) {
-        this.storeRequestSender.loadInstrumentsWithAddress(data, callback);
+    loadInstrumentsWithAddresses(data, callback) {
+        this.storeRequestSender.loadInstrumentsWithAddresses(data, callback);
     }
 
     /**

--- a/src/store/store-request-sender.js
+++ b/src/store/store-request-sender.js
@@ -4,7 +4,7 @@ import UrlHelper from './url-helper';
 import {
     mapToHeaders,
     mapToInstrumentPayload,
-    mapToTrustedShippingAddressPayload,
+    mapToTrustedShippingAddressesPayload,
 } from './v2/mappers';
 
 export default class StoreRequestSender {
@@ -59,7 +59,7 @@ export default class StoreRequestSender {
      */
     loadInstrumentsWithAddress(data, callback) {
         const url = this.urlHelper.getTrustedShippingAddressUrl(data.storeId, data.customerId);
-        const payload = mapToTrustedShippingAddressPayload(data);
+        const payload = mapToTrustedShippingAddressesPayload(data);
         const options = {
             method: POST,
             headers: mapToHeaders(data),

--- a/src/store/v2/mappers/index.js
+++ b/src/store/v2/mappers/index.js
@@ -26,12 +26,12 @@ export function mapToInstrumentPayload(data = {}) {
 
 /**
  * @param {Object} [data={}]
- * @param {Object} data.shippingAddress
+ * @param {AddressData[]} data.shippingAddresses
  * @return {Object}
  */
-export function mapToTrustedShippingAddressPayload(data = {}) {
+export function mapToTrustedShippingAddressesPayload(data = {}) {
     return omitNil({
-        shipping_address: mapToAddress(data.shippingAddress),
+        shipping_addresses: mapToAddresses(data.shippingAddresses),
     });
 }
 
@@ -44,6 +44,14 @@ export function mapToHeaders({ authToken: Authorization } = {}) {
     return omitNil({
         Authorization,
     });
+}
+
+/**
+ * @param {AddressData[]} addresses
+ * @return {Array}
+ */
+function mapToAddresses(addresses = []) {
+    return addresses.map(address => mapToAddress(address));
 }
 
 /**

--- a/test/client/client.spec.js
+++ b/test/client/client.spec.js
@@ -2,7 +2,7 @@ import merge from 'lodash/merge';
 import { HOSTED } from '../../src/payment/payment-types';
 import Client from '../../src/client/client';
 import paymentRequestDataMock from '../mocks/payment-request-data';
-import { storeIntrumentDataMock, trustedShippingAddressDataMock } from '../mocks/store-instrument-data';
+import { storeIntrumentDataMock, trustedShippingAddressesDataMock } from '../mocks/store-instrument-data';
 
 describe('Client', () => {
     let client;
@@ -30,7 +30,7 @@ describe('Client', () => {
         storeRequestSender = {
             getShopperToken: jasmine.createSpy('getShopperToken'),
             loadInstruments: jasmine.createSpy('loadInstruments'),
-            loadInstrumentsWithAddress: jasmine.createSpy('loadInstrumentsWithAddress'),
+            loadInstrumentsWithAddresses: jasmine.createSpy('loadInstrumentsWithAddresses'),
             postShopperInstrument: jasmine.createSpy('postShopperInstrument'),
             deleteShopperInstrument: jasmine.createSpy('deleteShopperInstrument'),
         };
@@ -102,11 +102,11 @@ describe('Client', () => {
 
     it('load instruments with shipping address', () => {
         const callback = () => {};
-        const data = trustedShippingAddressDataMock;
+        const data = trustedShippingAddressesDataMock;
 
-        client.loadInstrumentsWithAddress(data, callback);
+        client.loadInstrumentsWithAddresses(data, callback);
 
-        expect(storeRequestSender.loadInstrumentsWithAddress).toHaveBeenCalledWith(data, callback);
+        expect(storeRequestSender.loadInstrumentsWithAddresses).toHaveBeenCalledWith(data, callback);
     });
 
     it('posts a new instrument', () => {

--- a/test/mocks/store-instrument-data.js
+++ b/test/mocks/store-instrument-data.js
@@ -47,10 +47,10 @@ export const instrumentRequestDataMock = {
     defaultInstrument: true,
 };
 
-export const trustedShippingAddressDataMock = {
+export const trustedShippingAddressesDataMock = {
     storeId: '123',
     customerId: '321',
-    shippingAddress: {
+    shippingAddresses: [{
         addressLine1: '1-3 Smail St',
         addressLine2: 'Ultimo',
         city: 'Sydney',
@@ -63,5 +63,5 @@ export const trustedShippingAddressDataMock = {
         postCode: '2007',
         provinceCode: 'NSW',
         province: 'New South Wales',
-    },
+    }],
 };

--- a/test/store/store-request-sender.spec.js
+++ b/test/store/store-request-sender.spec.js
@@ -13,7 +13,7 @@ describe('StoreRequestSender', () => {
 
         spyOn(mappers, 'mapToHeaders');
         spyOn(mappers, 'mapToInstrumentPayload');
-        spyOn(mappers, 'mapToTrustedShippingAddressPayload');
+        spyOn(mappers, 'mapToTrustedShippingAddressesPayload');
 
         urlHelperMock = {
             getTokenUrl: jasmine.createSpy('getTokenUrl').and.callThrough(),
@@ -51,7 +51,7 @@ describe('StoreRequestSender', () => {
         expect(urlHelperMock.getTrustedShippingAddressUrl).toHaveBeenCalledWith(data.storeId, data.customerId);
         expect(requestSenderMock.postRequest).toHaveBeenCalled();
         expect(mappers.mapToHeaders).toHaveBeenCalled();
-        expect(mappers.mapToTrustedShippingAddressPayload).toHaveBeenCalled();
+        expect(mappers.mapToTrustedShippingAddressesPayload).toHaveBeenCalled();
     });
 
     it('posts a new shopper instrument with the appropriately mapped headers and payload', () => {

--- a/test/store/v2/mappers/index.spec.js
+++ b/test/store/v2/mappers/index.spec.js
@@ -1,12 +1,12 @@
 import {
     authTokenMock,
     instrumentRequestDataMock,
-    trustedShippingAddressDataMock,
+    trustedShippingAddressesDataMock,
 } from '../../../mocks/store-instrument-data';
 import {
     mapToInstrumentPayload,
     mapToHeaders,
-    mapToTrustedShippingAddressPayload,
+    mapToTrustedShippingAddressesPayload,
 } from '../../../../src/store/v2/mappers';
 
 describe('StoreMapper', () => {
@@ -86,37 +86,35 @@ describe('StoreMapper', () => {
     });
 
     it('maps the input object into a trusted shipping address object', () => {
-        const { shippingAddress } = trustedShippingAddressDataMock;
+        const { shippingAddresses } = trustedShippingAddressesDataMock;
 
-        const result = mapToTrustedShippingAddressPayload(trustedShippingAddressDataMock);
+        const result = mapToTrustedShippingAddressesPayload(trustedShippingAddressesDataMock);
         const expected = jasmine.objectContaining({
-            shipping_address: {
-                address_line_1: shippingAddress.addressLine1,
-                address_line_2: shippingAddress.addressLine2,
-                city: shippingAddress.city,
-                company: shippingAddress.company,
-                country_code: shippingAddress.countryCode,
-                email: shippingAddress.email,
-                first_name: shippingAddress.firstName,
-                last_name: shippingAddress.lastName,
-                phone: shippingAddress.phone,
-                postal_code: shippingAddress.postCode,
+            shipping_addresses: [{
+                address_line_1: shippingAddresses[0].addressLine1,
+                address_line_2: shippingAddresses[0].addressLine2,
+                city: shippingAddresses[0].city,
+                company: shippingAddresses[0].company,
+                country_code: shippingAddresses[0].countryCode,
+                email: shippingAddresses[0].email,
+                first_name: shippingAddresses[0].firstName,
+                last_name: shippingAddresses[0].lastName,
+                phone: shippingAddresses[0].phone,
+                postal_code: shippingAddresses[0].postCode,
                 state: {
-                    code: shippingAddress.provinceCode,
-                    name: shippingAddress.province,
+                    code: shippingAddresses[0].provinceCode,
+                    name: shippingAddresses[0].province,
                 },
-            },
+            }],
         });
 
         expect(result).toEqual(expected);
     });
 
     it('accepts null and returns an empty shipping address object', () => {
-        const result = mapToTrustedShippingAddressPayload();
+        const result = mapToTrustedShippingAddressesPayload();
         const expected = {
-            shipping_address: {
-                state: {},
-            },
+            shipping_addresses: [],
         };
 
         expect(result).toEqual(expected);


### PR DESCRIPTION
## What?
Add support for multiple shipping addressed to `loadInstrumentWithAddresses` 

## Why?
So support validation of stored credit cards 

## Testing / Proof
unit

ping @bigcommerce/payments @bigcommerce/checkout @filakhtov 
