### PR TITLE
INT-835 Add Google Pay to be supported as a payment method of braintree

### DIFF
--- a/src/payment/payment-method-ids.js
+++ b/src/payment/payment-method-ids.js
@@ -2,3 +2,4 @@ export const BRAINTREE = 'braintree';
 export const BRAINTREE_PAYPAL = 'braintreepaypal';
 export const BRAINTREE_PAYPAL_CREDIT = 'braintreepaypalcredit';
 export const BRAINTREE_VISACHECKOUT = 'braintreevisacheckout';
+export const BRAINTREE_GOOGLEPAY = 'googlepaybraintree';

--- a/src/payment/payment-method-mappers/payment-method-id-mapper.js
+++ b/src/payment/payment-method-mappers/payment-method-id-mapper.js
@@ -1,6 +1,7 @@
 import { MULTI_OPTION } from '../payment-method-types';
 import {
     BRAINTREE,
+    BRAINTREE_GOOGLEPAY,
     BRAINTREE_PAYPAL,
     BRAINTREE_PAYPAL_CREDIT,
     BRAINTREE_VISACHECKOUT,
@@ -15,6 +16,7 @@ function isBraintreePaymentMethod(id) {
     case BRAINTREE_PAYPAL:
     case BRAINTREE_PAYPAL_CREDIT:
     case BRAINTREE_VISACHECKOUT:
+    case BRAINTREE_GOOGLEPAY:
         return true;
     default:
         return false;

--- a/test/payment/payment-method-mappers/payment-method-id-mapper.spec.js
+++ b/test/payment/payment-method-mappers/payment-method-id-mapper.spec.js
@@ -45,4 +45,9 @@ describe('PaymentMethodIdMapper', () => {
         paymentMethod = { id: PAYMENT_METHODS.BRAINTREE_VISACHECKOUT };
         expect(paymentMethodIdMapper.mapToId(paymentMethod)).toEqual(PAYMENT_METHODS.BRAINTREE);
     });
+
+    it('returns "braintree" if the payment method is "googlepaybraintree"', () => {
+        paymentMethod = { id: PAYMENT_METHODS.BRAINTREE_GOOGLEPAY };
+        expect(paymentMethodIdMapper.mapToId(paymentMethod)).toEqual(PAYMENT_METHODS.BRAINTREE);
+    });
 });


### PR DESCRIPTION
## What?
To support Google Pay when a purchase, we need to add as a paymentMethod of Braintree to be mapped correctly to BigPay

## Why?
It needs to complete a E2E purchase using Google Pay + Braintree

## Testing / Proof

![image](https://user-images.githubusercontent.com/35146660/46550511-ef4b2c00-c89a-11e8-9c15-5a740b89ba56.png)

![image](https://user-images.githubusercontent.com/35146660/46550522-f40fe000-c89a-11e8-962f-01681c57845a.png)

ping @bigcommerce/payments @bigcommerce/integrations 