### PR TITLE
fix(payments): PAYMENTS-4228 remove currency code for when ID exists

### DIFF
--- a/src/store/store-request-sender.js
+++ b/src/store/store-request-sender.js
@@ -104,8 +104,7 @@ export default class StoreRequestSender {
         const url = this.urlHelper.getInstrumentByIdUrl(
             data.storeId,
             data.customerId,
-            data.instrumentId,
-            data.currencyCode
+            data.instrumentId
         );
         const options = {
             method: DELETE,

--- a/src/store/url-helper.js
+++ b/src/store/url-helper.js
@@ -58,10 +58,9 @@ export default class UrlHelper {
      * @param {number} storeId
      * @param {number} customerId
      * @param {number} instrumentId
-     * @param {string} currencyCode
      * @returns {string}
      */
-    getInstrumentByIdUrl(storeId, customerId, instrumentId, currencyCode) {
-        return `${this.host}/api/v2/stores/${storeId}/shoppers/${customerId}/instruments/${instrumentId}?currency_code=${currencyCode}`;
+    getInstrumentByIdUrl(storeId, customerId, instrumentId) {
+        return `${this.host}/api/v2/stores/${storeId}/shoppers/${customerId}/instruments/${instrumentId}`;
     }
 }

--- a/test/store/store-request-sender.spec.js
+++ b/test/store/store-request-sender.spec.js
@@ -80,8 +80,7 @@ describe('StoreRequestSender', () => {
         expect(urlHelperMock.getInstrumentByIdUrl).toHaveBeenCalledWith(
             data.storeId,
             data.customerId,
-            data.instrumentId,
-            data.currencyCode
+            data.instrumentId
         );
         expect(requestSenderMock.sendRequest).toHaveBeenCalled();
         expect(mappers.mapToHeaders).toHaveBeenCalled();

--- a/test/store/url-helper.spec.js
+++ b/test/store/url-helper.spec.js
@@ -48,8 +48,8 @@ describe('UrlHelper', () => {
     });
 
     it('returns a URL for generating a client token', () => {
-        const result = urlHelper.getInstrumentByIdUrl(storeId, shopperId, instrumentId, currencyCode);
-        const expected = `${host}/api/v2/stores/${storeId}/shoppers/${shopperId}/instruments/${instrumentId}?currency_code=${currencyCode}`;
+        const result = urlHelper.getInstrumentByIdUrl(storeId, shopperId, instrumentId);
+        const expected = `${host}/api/v2/stores/${storeId}/shoppers/${shopperId}/instruments/${instrumentId}`;
 
         expect(result).toEqual(expected);
     });


### PR DESCRIPTION
## What?
Remove the currency code requirement on the InstrumentsID url, where the ID is sufficient enough for what is intended.

## Why?
Unnecessary. Discussed with @capsula4 that it would be better without the currency code when we already pass in the ID.

## Testing / Proof
Specs updated.

## Used By
https://github.com/bigcommerce/checkout-sdk-js/pull/567

ping @bigcommerce/payments @bigcommerce/checkout 
