### PR TITLE
feat(payments): INT-1650 adding properties to vaulting object

### DIFF
--- a/src/payment/v1/payment-mappers/payment-mapper.js
+++ b/src/payment/v1/payment-mappers/payment-mapper.js
@@ -106,6 +106,7 @@ export default class PaymentMapper {
             credit_card_number_confirmation: payment.ccNumber,
             token: payment.instrumentId,
             verification_value: payment.ccCvv,
+            three_d_secure: payment.threeDSecure,
         });
     }
 

--- a/test/payment/v1/payment-mappers/payment-mapper.spec.js
+++ b/test/payment/v1/payment-mappers/payment-mapper.spec.js
@@ -148,6 +148,7 @@ describe('PaymentMapper', () => {
                 shouldSaveInstrument: true,
                 instrumentId: 'token1',
                 ccCvv: '123',
+                three_d_secure: { token: 'aaa.bbb.ccc' },
             },
         });
 
@@ -167,6 +168,7 @@ describe('PaymentMapper', () => {
                     token: data.payment.instrumentId,
                     verification_value: data.payment.ccCvv,
                     credit_card_number_confirmation: data.payment.ccNumber,
+                    three_d_secure: data.payment.three_d_secure,
                 },
             })
         );


### PR DESCRIPTION
[INT-1650](https://jira.bigcommerce.com/browse/INT-1650)

## What?
In `payment-mapper` I added new properties for vaulting in CBYS.

## Why?
It is needed to map that data to bigpay.

## Testing / Proof
<img width="660" alt="Captura de pantalla 2019-06-26 a la(s) 16 39 44" src="https://user-images.githubusercontent.com/4503787/60217121-91e47a00-9831-11e9-9b08-87177b712133.png">


@bigcommerce/payments @bigcommerce/intersys-integrations 
