### PR TITLE
PAYMENTS-4616 Allow a passthrough for payment data

### DIFF
--- a/src/payment/v1/payment-mappers/payment-mapper.js
+++ b/src/payment/v1/payment-mappers/payment-mapper.js
@@ -54,7 +54,9 @@ export default class PaymentMapper {
 
         const nonce = payment.nonce || paymentMethod.nonce;
 
-        if (payment.instrumentId) {
+        if (payment.formattedPayload) {
+            objectAssign(payload, payment.formattedPayload);
+        } else if (payment.instrumentId) {
             objectAssign(payload, {
                 bigpay_token: this.mapToBigPayToken(data),
             });

--- a/test/payment/v1/payment-mappers/payment-mapper.spec.js
+++ b/test/payment/v1/payment-mappers/payment-mapper.spec.js
@@ -234,4 +234,20 @@ describe('PaymentMapper', () => {
 
         expect(paymentMapper.mapToPayment({})).toEqual({ credit_card: {} });
     });
+
+    it('uses formattedPayload when provided', () => {
+        data = merge({}, data, {
+            payment: { formattedPayload: { credit_card_token: { token: '12356aaa' } } },
+        });
+
+        const output = paymentMapper.mapToPayment(data);
+
+        expect(output).toEqual(
+            jasmine.objectContaining({
+                credit_card_token: {
+                    token: '12356aaa',
+                },
+            })
+        );
+    });
 });


### PR DESCRIPTION
## What?
As per title

## Why?
We want to remove the mappers in bigpay, the proposed solution uses a new key within the payment object to indicate to this client it is safe to dump the whole content in the request to bigpay.

## Testing / Proof
- Unit

ping @bigcommerce/payments @bigcommerce/checkout 	
