### PR TITLE
[WIP] feat(payments): INT-1916 Add optional target parameter

### DIFF
--- a/src/client/client.js
+++ b/src/client/client.js
@@ -82,10 +82,11 @@ export default class Client {
     /**
      * @param {PaymentRequestData} data
      * @param {Function} [callback]
+     * @param {string} target
      * @returns {void}
      */
-    initializeOffsitePayment(data, callback) {
-        this.offsitePaymentInitializer.initializeOffsitePayment(data, callback);
+    initializeOffsitePayment(data, callback, target = '') {
+        this.offsitePaymentInitializer.initializeOffsitePayment(data, callback, target);
     }
 
     /**

--- a/src/payment/offsite-payment-initializer.js
+++ b/src/payment/offsite-payment-initializer.js
@@ -45,10 +45,11 @@ export default class OffsitePaymentInitializer {
     /**
      * @param {PaymentRequestData} data
      * @param {Function} [callback]
+     * @param {string} target
      * @returns {void}
      * @throws {Error}
      */
-    initializeOffsitePayment(data, callback) {
+    initializeOffsitePayment(data, callback, target = '') {
         const { paymentMethod = {} } = data;
 
         if (paymentMethod.type !== HOSTED) {
@@ -58,6 +59,6 @@ export default class OffsitePaymentInitializer {
         const payload = this.payloadMapper.mapToPayload(data);
         const url = this.urlHelper.getOffsitePaymentUrl();
 
-        this.formPoster.postForm(url, payload, callback);
+        this.formPoster.postForm(url, payload, callback, target);
     }
 }

--- a/test/client/client.spec.js
+++ b/test/client/client.spec.js
@@ -11,6 +11,7 @@ describe('Client', () => {
     let offsitePaymentInitializer;
     let paymentSubmitter;
     let storeRequestSender;
+    let target;
 
     beforeEach(() => {
         config = { host: 'https://bigpay.dev' };
@@ -34,6 +35,8 @@ describe('Client', () => {
             postShopperInstrument: jasmine.createSpy('postShopperInstrument'),
             deleteShopperInstrument: jasmine.createSpy('deleteShopperInstrument'),
         };
+
+        target = '';
 
         client = new Client(
             config,
@@ -60,7 +63,7 @@ describe('Client', () => {
         expect(instance instanceof Client).toEqual(true);
     });
 
-    it('initializes the offsite payment flow', () => {
+    it('initializes the offsite payment flow with the default target', () => {
         const callback = () => {};
         const data = merge({}, paymentRequestDataMock, {
             paymentMethod: {
@@ -70,7 +73,21 @@ describe('Client', () => {
 
         client.initializeOffsitePayment(data, callback);
 
-        expect(offsitePaymentInitializer.initializeOffsitePayment).toHaveBeenCalledWith(data, callback);
+        expect(offsitePaymentInitializer.initializeOffsitePayment).toHaveBeenCalledWith(data, callback, target);
+    });
+
+    it('initializes the offsite payment flow with the provided target', () => {
+        target = 'target_iframe';
+        const callback = () => {};
+        const data = merge({}, paymentRequestDataMock, {
+            paymentMethod: {
+                type: HOSTED,
+            },
+        });
+
+        client.initializeOffsitePayment(data, callback, target);
+
+        expect(offsitePaymentInitializer.initializeOffsitePayment).toHaveBeenCalledWith(data, callback, target);
     });
 
     it('submits the payment data', () => {

--- a/test/payment/offsite-payment-initializer.spec.js
+++ b/test/payment/offsite-payment-initializer.spec.js
@@ -8,6 +8,7 @@ describe('OffsitePaymentInitializer', () => {
     let formPoster;
     let offsitePaymentInitializer;
     let payloadMapper;
+    let target;
     let transformedData;
     let urlHelper;
 
@@ -32,6 +33,8 @@ describe('OffsitePaymentInitializer', () => {
             mapToPayload: jasmine.createSpy('mapToPayload').and.returnValue(transformedData),
         };
 
+        target = '';
+
         offsitePaymentInitializer = new OffsitePaymentInitializer(urlHelper, formPoster, payloadMapper);
     });
 
@@ -48,13 +51,23 @@ describe('OffsitePaymentInitializer', () => {
         expect(payloadMapper.mapToPayload).toHaveBeenCalled();
     });
 
-    it('posts the request payload containing payment information to the server using a hidden HTML form', () => {
+    it('posts the request payload containing payment information to the server using a hidden HTML form with the default target', () => {
         const callback = () => {};
         const url = urlHelper.getOffsitePaymentUrl();
 
         offsitePaymentInitializer.initializeOffsitePayment(data, callback);
 
-        expect(formPoster.postForm).toHaveBeenCalledWith(url, transformedData, callback);
+        expect(formPoster.postForm).toHaveBeenCalledWith(url, transformedData, callback, target);
+    });
+
+    it('posts the request payload containing payment information to the server using a hidden HTML form with the provided target', () => {
+        target = 'target_iframe';
+        const callback = () => {};
+        const url = urlHelper.getOffsitePaymentUrl();
+
+        offsitePaymentInitializer.initializeOffsitePayment(data, callback, target);
+
+        expect(formPoster.postForm).toHaveBeenCalledWith(url, transformedData, callback, target);
     });
 
     it('throws an error if the payment method is not a hosted provider', () => {


### PR DESCRIPTION
## What?
Add an additional parameter to the flow for an offsite payment provider.

## Why?
Enables a offsite payment provider to be initialized inside an iframe or any target other than `_top`

## Sibling PRs
https://github.com/bigcommerce/checkout-js/pull/143
https://github.com/bigcommerce/checkout-sdk-js/pull/721
https://github.com/bigcommerce/form-poster-js/pull/8

## Testing / Proof
<img width="689" alt="Screen Shot 2019-10-08 at 3 34 20 PM" src="https://user-images.githubusercontent.com/35502707/66431254-47060100-e9e1-11e9-8625-0c599de3b601.png">
<img width="504" alt="Screen Shot 2019-10-08 at 3 34 32 PM" src="https://user-images.githubusercontent.com/35502707/66431258-48cfc480-e9e1-11e9-8f1c-2169475326a3.png">
<img width="828" alt="Screen Shot 2019-10-08 at 3 34 47 PM" src="https://user-images.githubusercontent.com/35502707/66431262-4a998800-e9e1-11e9-83cf-09ad7d5cb2af.png">


ping @bigcommerce/intersys-integrations  @bigcommerce/payments 
