### PR TITLE
fix(instruments): PAYMENTS-4759 Remove POST instrument for api/v2

### DIFF
--- a/src/client/client.js
+++ b/src/client/client.js
@@ -135,22 +135,6 @@ export default class Client {
      * @param {Object} data
      * @param {string} data.storeId
      * @param {string} data.customerId
-     * @param {string} data.currencyCode
-     * @param {CreditCard} data.creditCard
-     * @param {AddressData} data.billingAddress
-     * @param {boolean} data.defaultInstrument
-     * @param {string} data.providerName
-     * @param {Function} [callback]
-     * @return {void}
-     */
-    postShopperInstrument(data, callback) {
-        this.storeRequestSender.postShopperInstrument(data, callback);
-    }
-
-    /**
-     * @param {Object} data
-     * @param {string} data.storeId
-     * @param {string} data.customerId
      * @param {string} data.instrumentId
      * @param {string} data.currencyCode
      * @param {Function} [callback]

--- a/src/store/store-request-sender.js
+++ b/src/store/store-request-sender.js
@@ -3,7 +3,6 @@ import { DELETE, POST } from '../common/http-request/method-types';
 import UrlHelper from './url-helper';
 import {
     mapToHeaders,
-    mapToInstrumentPayload,
     mapToTrustedShippingAddressPayload,
 } from './v2/mappers';
 
@@ -70,25 +69,6 @@ export default class StoreRequestSender {
         const payload = mapToTrustedShippingAddressPayload(data);
         const options = {
             method: POST,
-            headers: mapToHeaders(data),
-        };
-
-        this.requestSender.postRequest(url, payload, options, callback);
-    }
-
-    /**
-     * @param {Object} data
-     * @param {Function} [callback]
-     * @return {void}
-     */
-    postShopperInstrument(data, callback) {
-        const url = this.urlHelper.getInstrumentsUrl(
-            data.storeId,
-            data.customerId,
-            data.currencyCode
-        );
-        const payload = mapToInstrumentPayload(data);
-        const options = {
             headers: mapToHeaders(data),
         };
 

--- a/test/client/client.spec.js
+++ b/test/client/client.spec.js
@@ -31,7 +31,6 @@ describe('Client', () => {
             getShopperToken: jasmine.createSpy('getShopperToken'),
             loadInstruments: jasmine.createSpy('loadInstruments'),
             loadInstrumentsWithAddress: jasmine.createSpy('loadInstrumentsWithAddress'),
-            postShopperInstrument: jasmine.createSpy('postShopperInstrument'),
             deleteShopperInstrument: jasmine.createSpy('deleteShopperInstrument'),
         };
 
@@ -107,15 +106,6 @@ describe('Client', () => {
         client.loadInstrumentsWithAddress(data, callback);
 
         expect(storeRequestSender.loadInstrumentsWithAddress).toHaveBeenCalledWith(data, callback);
-    });
-
-    it('posts a new instrument', () => {
-        const callback = () => {};
-        const data = storeIntrumentDataMock;
-
-        client.postShopperInstrument(data, callback);
-
-        expect(storeRequestSender.postShopperInstrument).toHaveBeenCalledWith(data, callback);
     });
 
     it('deletes an instrument', () => {

--- a/test/store/store-request-sender.spec.js
+++ b/test/store/store-request-sender.spec.js
@@ -62,18 +62,6 @@ describe('StoreRequestSender', () => {
         expect(mappers.mapToTrustedShippingAddressPayload).toHaveBeenCalled();
     });
 
-    it('posts a new shopper instrument with the appropriately mapped headers and payload', () => {
-        storeRequestSender.postShopperInstrument(data, () => {});
-
-        expect(urlHelperMock.getInstrumentsUrl).toHaveBeenCalledWith(
-            data.storeId,
-            data.customerId,
-            data.currencyCode
-        );
-        expect(requestSenderMock.postRequest).toHaveBeenCalled();
-        expect(mappers.mapToHeaders).toHaveBeenCalled();
-    });
-
     it('requests the deletion of a shopper\'s payment instrument', () => {
         storeRequestSender.deleteShopperInstrument(data, () => {});
 


### PR DESCRIPTION
## What?
Remove the POST instrument method

## Why?
We do not have an api to respond to these requests. 
```
${this.host}/api/v2/stores/${storeId}/shoppers/${customerId}/instruments
```

## Testing / Proof
Unit

ping @bigcommerce/payments @bigcommerce/checkout 
