### PR TITLE
PAYMENTS-4759 Include new instrument types in the response

### DIFF
--- a/src/store/url-helper.js
+++ b/src/store/url-helper.js
@@ -41,7 +41,7 @@ export default class UrlHelper {
      * @returns {string}
      */
     getInstrumentsUrl(storeId, customerId, currencyCode) {
-        return `${this.host}/api/v2/stores/${storeId}/shoppers/${customerId}/instruments?currency_code=${currencyCode}`;
+        return `${this.host}/api/v3/stores/${storeId}/shoppers/${customerId}/instruments?currency_code=${currencyCode}`;
     }
 
     /**
@@ -51,7 +51,7 @@ export default class UrlHelper {
      * @return {string}
      */
     getTrustedShippingAddressUrl(storeId, customerId, currencyCode) {
-        return `${this.host}/api/v2/stores/${storeId}/shoppers/${customerId}/instruments/trusted_shipping_address?currency_code=${currencyCode}`;
+        return `${this.host}/api/v3/stores/${storeId}/shoppers/${customerId}/instruments/trusted_shipping_address?currency_code=${currencyCode}`;
     }
 
     /**

--- a/test/store/url-helper.spec.js
+++ b/test/store/url-helper.spec.js
@@ -35,14 +35,14 @@ describe('UrlHelper', () => {
 
     it('returns a URL for submitting payments to an offsite provider', () => {
         const result = urlHelper.getInstrumentsUrl(storeId, shopperId, currencyCode);
-        const expected = `${host}/api/v2/stores/${storeId}/shoppers/${shopperId}/instruments?currency_code=${currencyCode}`;
+        const expected = `${host}/api/v3/stores/${storeId}/shoppers/${shopperId}/instruments?currency_code=${currencyCode}`;
 
         expect(result).toEqual(expected);
     });
 
     it('returns a URL for posting a trusted shipping address', () => {
         const result = urlHelper.getTrustedShippingAddressUrl(storeId, shopperId, currencyCode);
-        const expected = `${host}/api/v2/stores/${storeId}/shoppers/${shopperId}/instruments/trusted_shipping_address?currency_code=${currencyCode}`;
+        const expected = `${host}/api/v3/stores/${storeId}/shoppers/${shopperId}/instruments/trusted_shipping_address?currency_code=${currencyCode}`;
 
         expect(result).toEqual(expected);
     });


### PR DESCRIPTION
## BREAKING CHANGES:
* Include new instrument types as part of the response. They need to be
handled by the consumer.

## What?
- Include all instruments as part of `loadInstruments`/`loadInstrumentsWithAddress`

## Why?
- Up until now these two methods only returned credit card instruments. From now onwards the endpoint might also return accounts. Consumers of this library need to take this into account and handle the new instrument types correctly.

## Testing / Proof
- Unit

ping @bigcommerce/checkout @bigcommerce/payments 
