### PR TITLE
fix expiry not valid error when vaulting CC

### DIFF
--- a/src/payment/v1/payment-mappers/payment-mapper.js
+++ b/src/payment/v1/payment-mappers/payment-mapper.js
@@ -1,6 +1,6 @@
 import objectAssign from 'object-assign';
 import PaymentMethodIdMapper from '../../payment-method-mappers/payment-method-id-mapper';
-import { omitNil, toNumber } from '../../../common/utils';
+import { omitNil, toNumber, toString } from '../../../common/utils';
 
 export default class PaymentMapper {
     /**
@@ -89,10 +89,10 @@ export default class PaymentMapper {
 
         return omitNil({
             account_name: payment.ccName,
-            month: payment.ccExpiry ? toNumber(payment.ccExpiry.month) : null,
+            month: payment.ccExpiry ? toString(payment.ccExpiry.month) : null,
             number: payment.ccNumber,
             verification_value: payment.ccCvv,
-            year: payment.ccExpiry ? toNumber(payment.ccExpiry.year) : null,
+            year: payment.ccExpiry ? toString(payment.ccExpiry.year) : null,
             customer_code: payment.ccCustomerCode,
             three_d_secure: payment.threeDSecure,
         });

--- a/test/payment/v1/payment-mappers/payment-mapper.spec.js
+++ b/test/payment/v1/payment-mappers/payment-mapper.spec.js
@@ -31,9 +31,9 @@ describe('PaymentMapper', () => {
             credit_card: {
                 account_name: data.payment.ccName,
                 number: data.payment.ccNumber,
-                month: parseInt(data.payment.ccExpiry.month, 10),
+                month: String(data.payment.ccExpiry.month),
                 verification_value: data.payment.ccCvv,
-                year: parseInt(data.payment.ccExpiry.year, 10),
+                year: String(data.payment.ccExpiry.year),
                 customer_code: data.payment.ccCustomerCode,
                 three_d_secure: data.payment.threeDSecure,
             },


### PR DESCRIPTION
expiry month and year must be string, year must be 4 digits

## What?
Cannot vault CC (using braintree)
re: https://github.com/bigcommerce/checkout-sdk-js/issues/522

## Why?
API expects strings, and payload cannot be coerced in checkout-sdk
