### PR TITLE
feat(payments): INT-1997 Add optional target parameter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@bigcommerce/bigpay-client",
-  "version": "5.0.1",
+  "version": "5.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@bigcommerce/form-poster": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@bigcommerce/form-poster/-/form-poster-1.2.1.tgz",
-      "integrity": "sha512-YuW1gMTtswu0c3aJRVegxESZ2raSk+HouHnI6yI7KV1ZujPb0FvBYN+6FYUMBE+NBPU9H2jcFAQUXzKldu685w=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@bigcommerce/form-poster/-/form-poster-1.4.0.tgz",
+      "integrity": "sha512-I6+yXbacr5Go0T15kAdW6EkNpOx9EwXB9aDqx1Q7b/I8ttDHH5Mvoq0vVMrC5y2xBClUKhsmBvNO46B/xEVOYA=="
     },
     "JSONStream": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "webpack": "^1.13.2"
   },
   "dependencies": {
-    "@bigcommerce/form-poster": "^1.2.1",
+    "@bigcommerce/form-poster": "^1.4.0",
     "deep-assign": "^2.0.0",
     "object-assign": "^4.1.0"
   }

--- a/src/client/client.js
+++ b/src/client/client.js
@@ -82,10 +82,11 @@ export default class Client {
     /**
      * @param {PaymentRequestData} data
      * @param {Function} [callback]
+     * @param {string} target
      * @returns {void}
      */
-    initializeOffsitePayment(data, callback) {
-        this.offsitePaymentInitializer.initializeOffsitePayment(data, callback);
+    initializeOffsitePayment(data, callback, target) {
+        this.offsitePaymentInitializer.initializeOffsitePayment(data, callback, target);
     }
 
     /**

--- a/src/payment/offsite-payment-initializer.js
+++ b/src/payment/offsite-payment-initializer.js
@@ -45,10 +45,11 @@ export default class OffsitePaymentInitializer {
     /**
      * @param {PaymentRequestData} data
      * @param {Function} [callback]
+     * @param {string} target
      * @returns {void}
      * @throws {Error}
      */
-    initializeOffsitePayment(data, callback) {
+    initializeOffsitePayment(data, callback, target) {
         const { paymentMethod = {} } = data;
 
         if (paymentMethod.type !== HOSTED) {
@@ -58,6 +59,6 @@ export default class OffsitePaymentInitializer {
         const payload = this.payloadMapper.mapToPayload(data);
         const url = this.urlHelper.getOffsitePaymentUrl();
 
-        this.formPoster.postForm(url, payload, callback);
+        this.formPoster.postForm(url, payload, callback, target);
     }
 }

--- a/test/client/client.spec.js
+++ b/test/client/client.spec.js
@@ -11,6 +11,7 @@ describe('Client', () => {
     let offsitePaymentInitializer;
     let paymentSubmitter;
     let storeRequestSender;
+    let target;
 
     beforeEach(() => {
         config = { host: 'https://bigpay.dev' };
@@ -33,6 +34,8 @@ describe('Client', () => {
             loadInstrumentsWithAddress: jasmine.createSpy('loadInstrumentsWithAddress'),
             deleteShopperInstrument: jasmine.createSpy('deleteShopperInstrument'),
         };
+
+        target = undefined;
 
         client = new Client(
             config,
@@ -59,7 +62,7 @@ describe('Client', () => {
         expect(instance instanceof Client).toEqual(true);
     });
 
-    it('initializes the offsite payment flow', () => {
+    it('initializes the offsite payment flow with the default target', () => {
         const callback = () => {};
         const data = merge({}, paymentRequestDataMock, {
             paymentMethod: {
@@ -69,7 +72,21 @@ describe('Client', () => {
 
         client.initializeOffsitePayment(data, callback);
 
-        expect(offsitePaymentInitializer.initializeOffsitePayment).toHaveBeenCalledWith(data, callback);
+        expect(offsitePaymentInitializer.initializeOffsitePayment).toHaveBeenCalledWith(data, callback, target);
+    });
+
+    it('initializes the offsite payment flow with the provided target', () => {
+        target = 'target_iframe';
+        const callback = () => {};
+        const data = merge({}, paymentRequestDataMock, {
+            paymentMethod: {
+                type: HOSTED,
+            },
+        });
+
+        client.initializeOffsitePayment(data, callback, target);
+
+        expect(offsitePaymentInitializer.initializeOffsitePayment).toHaveBeenCalledWith(data, callback, target);
     });
 
     it('submits the payment data', () => {

--- a/test/payment/offsite-payment-initializer.spec.js
+++ b/test/payment/offsite-payment-initializer.spec.js
@@ -8,6 +8,7 @@ describe('OffsitePaymentInitializer', () => {
     let formPoster;
     let offsitePaymentInitializer;
     let payloadMapper;
+    let target;
     let transformedData;
     let urlHelper;
 
@@ -32,6 +33,8 @@ describe('OffsitePaymentInitializer', () => {
             mapToPayload: jasmine.createSpy('mapToPayload').and.returnValue(transformedData),
         };
 
+        target = undefined;
+
         offsitePaymentInitializer = new OffsitePaymentInitializer(urlHelper, formPoster, payloadMapper);
     });
 
@@ -48,13 +51,23 @@ describe('OffsitePaymentInitializer', () => {
         expect(payloadMapper.mapToPayload).toHaveBeenCalled();
     });
 
-    it('posts the request payload containing payment information to the server using a hidden HTML form', () => {
+    it('posts the request payload containing payment information to the server using a hidden HTML form with the default target', () => {
         const callback = () => {};
         const url = urlHelper.getOffsitePaymentUrl();
 
         offsitePaymentInitializer.initializeOffsitePayment(data, callback);
 
-        expect(formPoster.postForm).toHaveBeenCalledWith(url, transformedData, callback);
+        expect(formPoster.postForm).toHaveBeenCalledWith(url, transformedData, callback, target);
+    });
+
+    it('posts the request payload containing payment information to the server using a hidden HTML form with the provided target', () => {
+        target = 'target_iframe';
+        const callback = () => {};
+        const url = urlHelper.getOffsitePaymentUrl();
+
+        offsitePaymentInitializer.initializeOffsitePayment(data, callback, target);
+
+        expect(formPoster.postForm).toHaveBeenCalledWith(url, transformedData, callback, target);
     });
 
     it('throws an error if the payment method is not a hosted provider', () => {


### PR DESCRIPTION
## What? [INT-1997](https://jira.bigcommerce.com/browse/INT-1997)
Add the target attribute as an optional parameter to build the form.

## Why?
To be able to display the response in a named iframe.

## Sibling PRs
[4] [bigcommerce/checkout-js](https://github.com/bigcommerce/checkout-js/pull/155) depends on:
[3] [bigcommerce/checkout-sdk-js](https://github.com/bigcommerce/checkout-sdk-js/pull/732) depends on:
[2] THIS PR depends on:
[1] [bigcommerce/form-poster-js](https://github.com/bigcommerce/form-poster-js/pull/9)

## Testing / Proof
![image](https://user-images.githubusercontent.com/4843328/67414525-e520cc00-f588-11e9-9eb8-4aa66a14c330.png)
![image](https://user-images.githubusercontent.com/4843328/67414564-f23dbb00-f588-11e9-8859-d49a4e48e42b.png)
![image](https://user-images.githubusercontent.com/4843328/67414601-02ee3100-f589-11e9-8f2c-727c1564c3e5.png)

ping @bigcommerce/payments @bigcommerce/intersys-integrations
