### PR TITLE
feat(instrument): INT-1780 Map customer id in offsite payment mapper

### DIFF
--- a/src/payment/offsite-payment-mappers/customer-mapper.js
+++ b/src/payment/offsite-payment-mappers/customer-mapper.js
@@ -20,6 +20,7 @@ export default class CustomerMapper {
             customer_email: customer.email,
             customer_first_name: customer.firstName,
             customer_geo_ip_country_code: quoteMeta.request ? quoteMeta.request.geoCountryCode : null,
+            customer_id: customer.customerId,
             customer_last_name: customer.lastName,
             customer_locale: store.storeLanguage,
             customer_name: customer.name,

--- a/test/payment/offsite-payment-mappers/customer-mapper.spec.js
+++ b/test/payment/offsite-payment-mappers/customer-mapper.spec.js
@@ -24,6 +24,7 @@ describe('CustomerMapper', () => {
             customer_email: data.customer.email,
             customer_first_name: data.customer.firstName,
             customer_geo_ip_country_code: data.quoteMeta.request.geoCountryCode,
+            customer_id: data.customer.customerId,
             customer_last_name: data.customer.lastName,
             customer_locale: data.store.storeLanguage,
             customer_name: data.customer.name,


### PR DESCRIPTION
## What?
Allow the field `customer_id` to be sent to bigpay when performing an offsite payment flow.

## Why?
Customer_id is a field required for the vaulting flow, it's sent by the regular payload mapper but not by the offsite payload mapper.

## Sibling PRs
https://github.com/bigcommerce/checkout-sdk-js/pull/742
https://github.com/bigcommerce/checkout-js/pull/176

## Testing / Proof
Request sent to bigpay:
<img width="880" alt="Screen Shot 2019-12-04 at 6 58 25 PM" src="https://user-images.githubusercontent.com/35502707/70194466-1fbd6e80-16c8-11ea-8223-d5a9c308322d.png">



ping @bigcommerce/intersys-integrations @bigcommerce/checkout 
