### PR TITLE
PAYMENTS-4848 send shipping transit time to bigpay

### DIFF
--- a/src/payment/v1/payment-mappers/order-mapper.js
+++ b/src/payment/v1/payment-mappers/order-mapper.js
@@ -50,12 +50,13 @@ export default class OrderMapper {
      * @return {Shipping[]}
      */
     mapToShipping(data) {
-        const { description } = data.shippingOption || {};
+        const { description, transitTime } = data.shippingOption || {};
 
         if (description) {
-            return [{
+            return [omitEmptyStringAndNil({
                 method: description,
-            }];
+                transit_time: transitTime,
+            })];
         }
 
         return [];

--- a/test/mocks/payment-request-data.js
+++ b/test/mocks/payment-request-data.js
@@ -144,7 +144,7 @@ const paymentRequestDataMock = {
         module: 'freeshipping',
         price: 15,
         selected: true,
-        transitTime: '',
+        transitTime: '3 business days',
     },
     source: 'bcapp-checkout-uco',
     store: {

--- a/test/payment/v1/payment-mappers/order-mapper.spec.js
+++ b/test/payment/v1/payment-mappers/order-mapper.spec.js
@@ -72,6 +72,7 @@ describe('OrderMapper', () => {
             ],
             shipping: [{
                 method: data.shippingOption.description,
+                transit_time: data.shippingOption.transitTime,
             }],
             shipping_address: {
                 city: data.shippingAddress.city,


### PR DESCRIPTION
## What?
send shipping transit time to bigpay

## Why?
So we can send it to providers who can make fraud decisions using the transit time

## Testing / Proof
Updated unit test

<img width="556" alt="Screen Shot 2019-11-14 at 3 09 48 pm" src="https://user-images.githubusercontent.com/19501762/68826176-df825600-06f0-11ea-8931-f90a61700da1.png">



ping @bigcommerce/payments 