### PR TITLE
feat(payments): INT-1778 Allow formattedPayload to be mapped on the offsite flow

### DIFF
--- a/src/payment/offsite-payment-mappers/payload-mapper.js
+++ b/src/payment/offsite-payment-mappers/payload-mapper.js
@@ -65,7 +65,7 @@ export default class PayloadMapper {
      * @returns {Object}
      */
     mapToPayload(data) {
-        const { authToken, order = {}, paymentMethod = {} } = data;
+        const { authToken, order = {}, payment = {}, paymentMethod = {} } = data;
 
         const payload = objectAssign(
             {
@@ -86,6 +86,10 @@ export default class PayloadMapper {
             this.addressMapper.mapToShippingAddress(data),
             this.storeMapper.mapToStore(data)
         );
+
+        const { formattedPayload = {} } = payment;
+
+        objectAssign(payload, formattedPayload);
 
         return omitNil(payload);
     }

--- a/test/payment/offsite-payment-mappers/payload-mapper.spec.js
+++ b/test/payment/offsite-payment-mappers/payload-mapper.spec.js
@@ -75,6 +75,20 @@ describe('PayloadMapper', () => {
         document.title = '';
     });
 
+    it('maps the formattedPayload fields if supplied', () => {
+        data = merge({}, paymentRequestDataMock, {
+            payment: {
+                formattedPayload: {
+                    sample_field: 'sample',
+                },
+            },
+        });
+
+        const output = payloadMapper.mapToPayload(data);
+
+        expect(output.sample_field).toEqual('sample');
+    });
+
     it('uses the return URL contained in the order object as a fallback', () => {
         data = merge({}, data, {
             order: {


### PR DESCRIPTION
## What?
Allow formattedPayload to be mapped on the offsite flow.

## Why?
so additional info can be sent to bigpay when required.

## Testing / Proof
<img width="633" alt="Screen Shot 2019-11-15 at 12 58 11 PM" src="https://user-images.githubusercontent.com/35502707/68968266-bd97da80-07a7-11ea-8ff9-69996d0ff3d3.png">


ping @bigcommerce/checkout @bigcommerce/payments @bigcommerce/intersys-integrations 
