### PR TITLE
fix(vaulting): PAYMENTS-4820 Add currency to checkout request to delete a stored card

### DIFF
--- a/src/store/store-request-sender.js
+++ b/src/store/store-request-sender.js
@@ -84,7 +84,8 @@ export default class StoreRequestSender {
         const url = this.urlHelper.getInstrumentByIdUrl(
             data.storeId,
             data.customerId,
-            data.instrumentId
+            data.instrumentId,
+            data.currencyCode
         );
         const options = {
             method: DELETE,

--- a/src/store/url-helper.js
+++ b/src/store/url-helper.js
@@ -58,9 +58,10 @@ export default class UrlHelper {
      * @param {number} storeId
      * @param {number} customerId
      * @param {number} instrumentId
+     * @param {string} currencyCode
      * @returns {string}
      */
-    getInstrumentByIdUrl(storeId, customerId, instrumentId) {
-        return `${this.host}/api/v2/stores/${storeId}/shoppers/${customerId}/instruments/${instrumentId}`;
+    getInstrumentByIdUrl(storeId, customerId, instrumentId, currencyCode) {
+        return `${this.host}/api/v2/stores/${storeId}/shoppers/${customerId}/instruments/${instrumentId}?currency_code=${currencyCode}`;
     }
 }

--- a/test/store/store-request-sender.spec.js
+++ b/test/store/store-request-sender.spec.js
@@ -68,7 +68,8 @@ describe('StoreRequestSender', () => {
         expect(urlHelperMock.getInstrumentByIdUrl).toHaveBeenCalledWith(
             data.storeId,
             data.customerId,
-            data.instrumentId
+            data.instrumentId,
+            data.currencyCode
         );
         expect(requestSenderMock.sendRequest).toHaveBeenCalled();
         expect(mappers.mapToHeaders).toHaveBeenCalled();

--- a/test/store/url-helper.spec.js
+++ b/test/store/url-helper.spec.js
@@ -48,8 +48,8 @@ describe('UrlHelper', () => {
     });
 
     it('returns a URL for generating a client token', () => {
-        const result = urlHelper.getInstrumentByIdUrl(storeId, shopperId, instrumentId);
-        const expected = `${host}/api/v2/stores/${storeId}/shoppers/${shopperId}/instruments/${instrumentId}`;
+        const result = urlHelper.getInstrumentByIdUrl(storeId, shopperId, instrumentId, currencyCode);
+        const expected = `${host}/api/v2/stores/${storeId}/shoppers/${shopperId}/instruments/${instrumentId}?currency_code=${currencyCode}`;
 
         expect(result).toEqual(expected);
     });


### PR DESCRIPTION
## What?
When deleting a stored credit card from "Manage" in the checkout, the frontend should also send currency with the request to BigPay. The `?currency_code=...` parameter should be added to the request.

## Why?
When using the "Manage Cards" modal in checkout to delete a stored card, it doesn't include the transactional currency code with the request. This means that we can't be sure that we're fetching the correct config to use to remove the card.

## Testing / Proof
Screenshots

**Before**
<img width="969" alt="Screen Shot 2019-11-22 at 9 30 46 am" src="https://user-images.githubusercontent.com/36555311/69382327-f3d6dc00-0d0a-11ea-9a91-bd60b2280b7c.png">

**After**
<img width="970" alt="Screen Shot 2019-11-22 at 9 21 15 am" src="https://user-images.githubusercontent.com/36555311/69382064-5a0f2f00-0d0a-11ea-994e-ae4a98d57a43.png">

ping @bigcommerce/payments
