### PR TITLE
fix(payment): PAYMENTS-5037 Add Item Unit Price to Line Item object in…

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ export default function getPaymentData() {
                     integerAmountAfterDiscount: 10000,
                     integerDiscount: 0,
                     integerTax: 1000,
+                    integerUnitPrice: 10000,
+                    integerUnitPriceAfterDiscount: 10000,
                     name: 'Cheese',
                     quantity: 1,
                     sku: '123456789',

--- a/src/payment/v1/payment-mappers/order-mapper.js
+++ b/src/payment/v1/payment-mappers/order-mapper.js
@@ -122,6 +122,7 @@ export default class OrderMapper {
             variant_id: itemData.variantId,
             name: itemData.name,
             price: itemData.integerAmount,
+            unit_price: itemData.integerUnitPrice,
             quantity: itemData.quantity,
             sku: itemData.sku,
         }));

--- a/src/payment/v2/payment-mappers/cart-mapper.js
+++ b/src/payment/v2/payment-mappers/cart-mapper.js
@@ -34,6 +34,7 @@ export default class CartMapper {
             discount_amount: itemData.integerDiscount,
             name: itemData.name,
             price: itemData.integerAmount,
+            unit_price: itemData.integerUnitPrice,
             quantity: itemData.quantity,
             sku: itemData.sku,
             tax_amount: itemData.integerTax,

--- a/test/mocks/payment-request-data.js
+++ b/test/mocks/payment-request-data.js
@@ -43,6 +43,8 @@ const paymentRequestDataMock = {
                 integerAmountAfterDiscount: 10000,
                 integerDiscount: 0,
                 integerTax: 1000,
+                integerUnitPrice: 10000,
+                integerUnitPriceAfterDiscount: 10000,
                 name: 'Cheese',
                 quantity: 1,
                 sku: '123456789',

--- a/test/payment/v1/payment-mappers/order-mapper.spec.js
+++ b/test/payment/v1/payment-mappers/order-mapper.spec.js
@@ -65,6 +65,7 @@ describe('OrderMapper', () => {
                     code: data.cart.items[0].id,
                     name: data.cart.items[0].name,
                     price: data.cart.items[0].integerAmount,
+                    unit_price: data.cart.items[0].integerUnitPrice,
                     variant_id: data.cart.items[0].variantId,
                     quantity: data.cart.items[0].quantity,
                     sku: data.cart.items[0].sku,

--- a/test/payment/v2/payment-mappers/cart-mapper.spec.js
+++ b/test/payment/v2/payment-mappers/cart-mapper.spec.js
@@ -25,6 +25,7 @@ describe('CartMapper', () => {
                 discount_amount: item.integerDiscount,
                 name: item.name,
                 price: item.integerAmount,
+                unit_price: item.integerUnitPrice,
                 quantity: item.quantity,
                 sku: item.sku,
                 tax_amount: item.integerTax,


### PR DESCRIPTION
… order payment payload

## What?
Add`unit_price` to `/api/public/v1/orders/payments` payload.

This PR is a dependent on another sibling checkout-sdk-js PR: https://github.com/bigcommerce/checkout-sdk-js/pull/772.

## Why?
In the payload for a post to `/api/public/v1/orders/payments` the order details contains item information. Under `items` in the payload, the `price` field is reflecting the line item price (unit price x qty) rather than the unit price. 
This is affecting some payment providers which are expecting price to be for a single item.

## Testing / Proof
Unit tests
Screenshot
<img width="949" alt="Screen Shot 2020-01-07 at 5 57 46 pm" src="https://user-images.githubusercontent.com/36555311/71939564-3bf08600-3207-11ea-94ed-ad3c5167f136.png">

@bigcommerce/payments
