### PR TITLE
[WIP] fix(instruments): INT-2332 Cleanup JWT in offsite flow

### DIFF
--- a/src/payment/offsite-payment-mappers/payload-mapper.js
+++ b/src/payment/offsite-payment-mappers/payload-mapper.js
@@ -70,7 +70,7 @@ export default class PayloadMapper {
         const payload = objectAssign(
             {
                 amount: order.grandTotal ? order.grandTotal.integerAmount : null,
-                bc_auth_token: authToken,
+                bc_auth_token: this.cleanBigPayJWT(authToken),
                 currency: order.currency,
                 gateway: this.paymentMethodIdMapper.mapToId(paymentMethod),
                 notify_url: order.callbackUrl,
@@ -92,5 +92,18 @@ export default class PayloadMapper {
         objectAssign(payload, formattedPayload);
 
         return omitNil(payload);
+    }
+
+    /**
+     * @private
+     * @param {string} token
+     * @return {string}
+     */
+    cleanBigPayJWT(token) {
+        if (token && token.indexOf(',') !== -1) {
+            return token.substring(0, token.indexOf(','));
+        }
+
+        return token;
     }
 }

--- a/test/payment/offsite-payment-mappers/payload-mapper.spec.js
+++ b/test/payment/offsite-payment-mappers/payload-mapper.spec.js
@@ -75,6 +75,16 @@ describe('PayloadMapper', () => {
         document.title = '';
     });
 
+    it('cleans the authToken if it contains more than one token', () => {
+        data = merge({}, paymentRequestDataMock, {
+            authToken: 'aaa.bbb.ccc, ddd.eee.fff',
+        });
+
+        const output = payloadMapper.mapToPayload(data);
+
+        expect(output.bc_auth_token).toEqual('aaa.bbb.ccc');
+    });
+
     it('maps the formattedPayload fields if supplied', () => {
         data = merge({}, paymentRequestDataMock, {
             payment: {


### PR DESCRIPTION
## What?
Cleanup the JWT token in the offsite payments flow.

## Why?
Checkout SDK joins a JWT with a VAT on a regular flow when using a vaulted instrument, but in offsite payment scenarios with vaulted instruments the backend does not parse correctly this token, causing an error.

## Testing / Proof
...

ping {suggested reviewers}
