### PR TITLE
feat(payments): PAYPAL-293 Add paypalcommerce to payment methods

### DIFF
--- a/src/payment/payment-method-ids.js
+++ b/src/payment/payment-method-ids.js
@@ -3,3 +3,6 @@ export const BRAINTREE_PAYPAL = 'braintreepaypal';
 export const BRAINTREE_PAYPAL_CREDIT = 'braintreepaypalcredit';
 export const BRAINTREE_VISACHECKOUT = 'braintreevisacheckout';
 export const BRAINTREE_GOOGLEPAY = 'googlepaybraintree';
+
+export const PAYPAL_COMMERCE = 'paypalcommerce';
+export const PAYPAL_COMMERCE_CREDIT = 'paypalcommercecredit';

--- a/src/payment/payment-method-mappers/payment-method-id-mapper.js
+++ b/src/payment/payment-method-mappers/payment-method-id-mapper.js
@@ -5,6 +5,8 @@ import {
     BRAINTREE_PAYPAL,
     BRAINTREE_PAYPAL_CREDIT,
     BRAINTREE_VISACHECKOUT,
+    PAYPAL_COMMERCE,
+    PAYPAL_COMMERCE_CREDIT,
 } from '../payment-method-ids';
 
 /**
@@ -21,6 +23,14 @@ function isBraintreePaymentMethod(id) {
     default:
         return false;
     }
+}
+
+/**
+ * @param {string} id
+ * @return {Boolean}
+ */
+function isPaypalCommercePaymentMethod(id) {
+    return (id === PAYPAL_COMMERCE_CREDIT);
 }
 
 export default class PaymentMethodIdMapper {
@@ -44,6 +54,10 @@ export default class PaymentMethodIdMapper {
 
         if (isBraintreePaymentMethod(id)) {
             return BRAINTREE;
+        }
+
+        if (isPaypalCommercePaymentMethod(id)) {
+            return PAYPAL_COMMERCE;
         }
 
         return id;

--- a/test/payment/payment-method-mappers/payment-method-id-mapper.spec.js
+++ b/test/payment/payment-method-mappers/payment-method-id-mapper.spec.js
@@ -50,4 +50,9 @@ describe('PaymentMethodIdMapper', () => {
         paymentMethod = { id: PAYMENT_METHODS.BRAINTREE_GOOGLEPAY };
         expect(paymentMethodIdMapper.mapToId(paymentMethod)).toEqual(PAYMENT_METHODS.BRAINTREE);
     });
+
+    it('returns "paypalcommerce" if the payment method is "paypalcommercecredit"', () => {
+        paymentMethod = { id: PAYMENT_METHODS.PAYPAL_COMMERCE_CREDIT };
+        expect(paymentMethodIdMapper.mapToId(paymentMethod)).toEqual(PAYMENT_METHODS.PAYPAL_COMMERCE);
+    });
 });


### PR DESCRIPTION
## What?
Add paypalcommerce to payment methods

## Why?
Because of the way Paypal Credit on Paypal Commerce is expected to be received by BigPay (like braintree). Bigpay should get "gateway: 'paypalcommerce'" (not 'paypalcommercecredit')

## Testing / Proof
...

ping {suggested reviewers}
