### PR TITLE
feat(payment): PAYMENTS-5425 Update payload-mapper for Carding remediation solution

### DIFF
--- a/src/payment/v1/payment-mappers/payload-mapper.js
+++ b/src/payment/v1/payment-mappers/payload-mapper.js
@@ -54,7 +54,7 @@ export default class PayloadMapper {
      * @returns {Object}
      */
     mapToPayload(data) {
-        const { order = {} } = data;
+        const { order = {}, additionalAction } = data;
 
         return omitNil({
             customer: this.customerMapper.mapToCustomer(data),
@@ -62,6 +62,7 @@ export default class PayloadMapper {
             order: this.orderMapper.mapToOrder(data),
             payment: this.paymentMapper.mapToPayment(data),
             store: this.storeMapper.mapToStore(data),
+            additional_action: additionalAction,
         });
     }
 


### PR DESCRIPTION
## What?
For credit card payment, after checkout sdk sends payment payload to BigPay, if `human_verification_required` response is returned from BigPay, Google Recaptcha instance is created to verify that the shopper is a human. It's invisible if Google thinks the shopper is human, and shows a challenge if Google thinks the shopper is a bot. 

Once ReCAPTCHA is completed, it'll re-send the payment request to BigPay with almost the same payload, except for a new `additional_action` property including the additional token that was just created when completing the ReCAPTCHA.

Sibling PR on checkout-sdk-js: https://github.com/bigcommerce/checkout-sdk-js/pull/875

## Why?
To protect our stores from spammers using long lists of credit cards number to place fraudulent orders.

## Testing / Proof
Screen records
**Visible Recaptcha**
![Cybersourse-visible (1)](https://user-images.githubusercontent.com/36555311/82164446-fd28b600-98f3-11ea-8118-d8c637581fc9.gif)

**Invisible Recaptcha** (notice Google recaptcha logo on the bottom right corner of screen)
![BT-invisible (1)](https://user-images.githubusercontent.com/36555311/82164524-6f00ff80-98f4-11ea-97fc-1c1ee79d5488.gif)


@bigcommerce/checkout @bigcommerce/payments
