### PR TITLE
feat(payment): PAYMENTS-5513 add set_as_default_stored_instrument

### DIFF
--- a/src/payment/v1/payment-mappers/payment-mapper.js
+++ b/src/payment/v1/payment-mappers/payment-mapper.js
@@ -44,6 +44,7 @@ export default class PaymentMapper {
             notify_url: order.callbackUrl,
             return_url: paymentMethod.returnUrl || (order.payment ? order.payment.returnUrl : null),
             vault_payment_instrument: !payment.instrumentId ? payment.shouldSaveInstrument : null,
+            set_as_default_stored_instrument: (payment.instrumentId || payment.shouldSaveInstrument) ? payment.setAsDefaultInstrument : null,
         };
 
         const { method } = paymentMethod;

--- a/test/payment/v1/payment-mappers/payment-mapper.spec.js
+++ b/test/payment/v1/payment-mappers/payment-mapper.spec.js
@@ -174,6 +174,26 @@ describe('PaymentMapper', () => {
         );
     });
 
+    it('maps requests for vaulted instrument to be made default', () => {
+        data = merge({}, data, {
+            payment: {
+                shouldSaveInstrument: true,
+                instrumentId: 'token1',
+                ccCvv: '123',
+                three_d_secure: { token: 'aaa.bbb.ccc' },
+                setAsDefaultInstrument: true,
+            },
+        });
+
+        const output = paymentMapper.mapToPayment(data);
+
+        expect(output).toEqual(
+            expect.objectContaining({
+                set_as_default_stored_instrument: true,
+            }),
+        );
+    });
+
     it('maps requests for instrument to be vaulted', () => {
         data = merge({}, data, {
             payment: {
@@ -187,6 +207,57 @@ describe('PaymentMapper', () => {
         expect(output).toEqual(
             expect.objectContaining({
                 vault_payment_instrument: data.payment.shouldSaveInstrument,
+            }),
+        );
+    });
+
+    it('maps requests for instrument to be vaulted AND made default', () => {
+        data = merge({}, data, {
+            payment: {
+                shouldSaveInstrument: true,
+                setAsDefaultInstrument: true,
+            },
+        });
+
+        const output = paymentMapper.mapToPayment(data);
+
+        expect(output).toEqual(
+            expect.objectContaining({
+                set_as_default_stored_instrument: true,
+            }),
+        );
+    });
+
+    it('ignores requests to set non-vaulted instruments as default', () => {
+        data = merge({}, data, {
+            payment: {
+                instrumentId: undefined,
+                setAsDefaultInstrument: true,
+            },
+        });
+
+        const output = paymentMapper.mapToPayment(data);
+
+        expect(output).not.toEqual(
+            expect.objectContaining({
+                set_as_default_stored_instrument: true,
+            }),
+        );
+    });
+
+    it('ignores requests to set an instrument that is not about to be vaulted, as default', () => {
+        data = merge({}, data, {
+            payment: {
+                shouldSaveInstrument: false,
+                setAsDefaultInstrument: true,
+            },
+        });
+
+        const output = paymentMapper.mapToPayment(data);
+
+        expect(output).not.toEqual(
+            expect.objectContaining({
+                set_as_default_stored_instrument: true,
             }),
         );
     });


### PR DESCRIPTION
add `set_as_default_vaulted_instrument` mapping

## What?
map incoming `setAsDefaultInstrument` payloads to `set_as_default_stored_instrument`

## Why?
to allow the checkout-sdk to send flags of `setAsDefaultInstrument` during payments, which this code remaps and sends on to the API as `set_as_default_stored_instrument` - in order to achieve the users objective of making that instrument their default going forward

## Testing / Proof
unit tests

ping {suggested reviewers}
