### PR TITLE
CHECKOUT-4973: Add hosted_form_nonce to payment request object

### DIFF
--- a/src/payment/v1/payment-mappers/payment-mapper.js
+++ b/src/payment/v1/payment-mappers/payment-mapper.js
@@ -1,6 +1,7 @@
 import objectAssign from 'object-assign';
-import PaymentMethodIdMapper from '../../payment-method-mappers/payment-method-id-mapper';
 import { omitNil, toNumber } from '../../../common/utils';
+
+import PaymentMethodIdMapper from '../../payment-method-mappers/payment-method-id-mapper';
 
 export default class PaymentMapper {
     /**
@@ -96,6 +97,7 @@ export default class PaymentMapper {
             year: payment.ccExpiry ? toNumber(payment.ccExpiry.year) : null,
             customer_code: payment.ccCustomerCode,
             three_d_secure: payment.threeDSecure,
+            hosted_form_nonce: payment.hostedFormNonce,
         });
     }
 

--- a/test/mocks/payment-request-data.js
+++ b/test/mocks/payment-request-data.js
@@ -110,6 +110,7 @@ const paymentRequestDataMock = {
         threeDSecure: {
             token: 'aaa.bbb.ccc',
         },
+        hostedFormNonce: 'fakeHostedFormNonce',
     },
     paymentMethod: {
         id: 'paypalprous',

--- a/test/payment/v1/payment-mappers/payment-mapper.spec.js
+++ b/test/payment/v1/payment-mappers/payment-mapper.spec.js
@@ -1,5 +1,5 @@
-import omit from 'lodash/omit';
 import merge from 'lodash/merge';
+import omit from 'lodash/omit';
 import PaymentMapper from '../../../../src/payment/v1/payment-mappers/payment-mapper';
 import paymentRequestDataMock from '../../../mocks/payment-request-data';
 
@@ -36,6 +36,7 @@ describe('PaymentMapper', () => {
                 year: parseInt(data.payment.ccExpiry.year, 10),
                 customer_code: data.payment.ccCustomerCode,
                 three_d_secure: data.payment.threeDSecure,
+                hosted_form_nonce: data.payment.hostedFormNonce,
             },
             device: {
                 fingerprint_id: data.orderMeta.deviceFingerprint,


### PR DESCRIPTION
## What?
Send an additional field when making credit card payment

## Why?
See above

## Testing / Proof
Unit

ping @bigcommerce/payments @bigcommerce/checkout 
