### PR TITLE
CHECKOUT-4947: Forward payment method nonce when paying with stored instrument for card verification

### DIFF
--- a/src/payment/v1/payment-mappers/payment-mapper.js
+++ b/src/payment/v1/payment-mappers/payment-mapper.js
@@ -111,6 +111,7 @@ export default class PaymentMapper {
             credit_card_number_confirmation: payment.ccNumber,
             token: payment.instrumentId,
             verification_value: payment.ccCvv,
+            verification_nonce: payment.nonce,
             three_d_secure: payment.threeDSecure,
         });
     }

--- a/test/payment/v1/payment-mappers/payment-mapper.spec.js
+++ b/test/payment/v1/payment-mappers/payment-mapper.spec.js
@@ -175,6 +175,24 @@ describe('PaymentMapper', () => {
         );
     });
 
+    it('maps vaulting data with verification nonce to payload format', () => {
+        data = merge({}, data, {
+            payment: {
+                instrumentId: 'token1',
+                nonce: 'verification_nonce',
+            },
+        });
+
+        const output = paymentMapper.mapToPayment(data);
+
+        expect(output.bigpay_token).toEqual(
+            expect.objectContaining({
+                token: data.payment.instrumentId,
+                verification_nonce: data.payment.nonce,
+            }),
+        );
+    });
+
     it('maps requests for vaulted instrument to be made default', () => {
         data = merge({}, data, {
             payment: {


### PR DESCRIPTION
## What?
When paying with a stored instrument, forward the payment method nonce for the purpose of card verification. 

## Why?
When using Braintree hosted fields, the client app only has access to tokenised credit card information. So we can only forward that to the server for verification.

## Testing / Proof
Unit

ping @bigcommerce/payments @bigcommerce/checkout 
