### PR TITLE
feat(payments): PAYMENTS-5513 rename setAsDefaultInstrument to shouldSetAsDefaultInstrument

### DIFF
--- a/src/payment/v1/payment-mappers/payment-mapper.js
+++ b/src/payment/v1/payment-mappers/payment-mapper.js
@@ -45,7 +45,7 @@ export default class PaymentMapper {
             notify_url: order.callbackUrl,
             return_url: paymentMethod.returnUrl || (order.payment ? order.payment.returnUrl : null),
             vault_payment_instrument: !payment.instrumentId ? payment.shouldSaveInstrument : null,
-            set_as_default_stored_instrument: (payment.instrumentId || payment.shouldSaveInstrument) ? payment.setAsDefaultInstrument : null,
+            set_as_default_stored_instrument: (payment.instrumentId || payment.shouldSaveInstrument) ? payment.shouldSetAsDefaultInstrument : null,
         };
 
         const { method } = paymentMethod;

--- a/test/payment/v1/payment-mappers/payment-mapper.spec.js
+++ b/test/payment/v1/payment-mappers/payment-mapper.spec.js
@@ -182,7 +182,7 @@ describe('PaymentMapper', () => {
                 instrumentId: 'token1',
                 ccCvv: '123',
                 three_d_secure: { token: 'aaa.bbb.ccc' },
-                setAsDefaultInstrument: true,
+                shouldSetAsDefaultInstrument: true,
             },
         });
 
@@ -216,7 +216,7 @@ describe('PaymentMapper', () => {
         data = merge({}, data, {
             payment: {
                 shouldSaveInstrument: true,
-                setAsDefaultInstrument: true,
+                shouldSetAsDefaultInstrument: true,
             },
         });
 
@@ -233,7 +233,7 @@ describe('PaymentMapper', () => {
         data = merge({}, data, {
             payment: {
                 instrumentId: undefined,
-                setAsDefaultInstrument: true,
+                shouldSetAsDefaultInstrument: true,
             },
         });
 
@@ -250,7 +250,7 @@ describe('PaymentMapper', () => {
         data = merge({}, data, {
             payment: {
                 shouldSaveInstrument: false,
-                setAsDefaultInstrument: true,
+                shouldSetAsDefaultInstrument: true,
             },
         });
 


### PR DESCRIPTION
## What?
rename setAsDefaultInstrument to shouldSetAsDefaultInstrument (JS client facing change, not Payments API facing)

## Why?
to move more inline with the standard set in `checkout-sdk-js`

## Testing / Proof
passing tests

ping {suggested reviewers}
