### PR TITLE
PAYPAL-202 Add paypalcommercecreditcards to PaymentMethodIdMapper

### DIFF
--- a/src/payment/payment-method-ids.js
+++ b/src/payment/payment-method-ids.js
@@ -6,3 +6,4 @@ export const BRAINTREE_GOOGLEPAY = 'googlepaybraintree';
 
 export const PAYPAL_COMMERCE = 'paypalcommerce';
 export const PAYPAL_COMMERCE_CREDIT = 'paypalcommercecredit';
+export const PAYPAL_COMMERCE_CREDIT_CARDS = 'paypalcommercecreditcards';

--- a/src/payment/payment-method-mappers/payment-method-id-mapper.js
+++ b/src/payment/payment-method-mappers/payment-method-id-mapper.js
@@ -7,6 +7,7 @@ import {
     BRAINTREE_VISACHECKOUT,
     PAYPAL_COMMERCE,
     PAYPAL_COMMERCE_CREDIT,
+    PAYPAL_COMMERCE_CREDIT_CARDS,
 } from '../payment-method-ids';
 
 /**
@@ -30,7 +31,13 @@ function isBraintreePaymentMethod(id) {
  * @return {Boolean}
  */
 function isPaypalCommercePaymentMethod(id) {
-    return (id === PAYPAL_COMMERCE_CREDIT);
+    switch (id) {
+    case PAYPAL_COMMERCE_CREDIT:
+    case PAYPAL_COMMERCE_CREDIT_CARDS:
+        return true;
+    default:
+        return false;
+    }
 }
 
 export default class PaymentMethodIdMapper {

--- a/test/payment/payment-method-mappers/payment-method-id-mapper.spec.js
+++ b/test/payment/payment-method-mappers/payment-method-id-mapper.spec.js
@@ -55,4 +55,9 @@ describe('PaymentMethodIdMapper', () => {
         paymentMethod = { id: PAYMENT_METHODS.PAYPAL_COMMERCE_CREDIT };
         expect(paymentMethodIdMapper.mapToId(paymentMethod)).toEqual(PAYMENT_METHODS.PAYPAL_COMMERCE);
     });
+
+    it('returns "paypalcommerce" if the payment method is "paypalcommercecreditcards"', () => {
+        paymentMethod = { id: PAYMENT_METHODS.PAYPAL_COMMERCE_CREDIT_CARDS };
+        expect(paymentMethodIdMapper.mapToId(paymentMethod)).toEqual(PAYMENT_METHODS.PAYPAL_COMMERCE);
+    });
 });


### PR DESCRIPTION
## What?
Add paypalcommercecreditcards to PaymentMethodIdMapper

## Why?
Because of the way Paypal Credit Cards on Paypal Commerce is expected to be received by BigPay (like braintree). Bigpay should get "gateway: 'paypalcommerce'" (not 'paypalcommercecreditcards')

## Testing / Proof 
Unit

ping @bigcommerce/payments @bigcommerce/checkout
