### PR TITLE
feat(payments): INT-4430 mapping store name for offsite providers

### DIFF
--- a/src/payment/offsite-payment-mappers/store-mapper.js
+++ b/src/payment/offsite-payment-mappers/store-mapper.js
@@ -18,6 +18,7 @@ export default class StoreMapper {
         return omitNil({
             store_hash: store.storeHash,
             store_id: store.storeId ? toString(store.storeId) : null,
+            store_name: store.storeName ? toString(store.storeName) : null,
         });
     }
 }

--- a/test/payment/offsite-payment-mappers/store-mapper.spec.js
+++ b/test/payment/offsite-payment-mappers/store-mapper.spec.js
@@ -23,6 +23,7 @@ describe('StoreMapper', () => {
         expect(output).toEqual({
             store_hash: data.store.storeHash,
             store_id: data.store.storeId,
+            store_name: data.store.storeName,
         });
     });
 


### PR DESCRIPTION
## What?
Added store name to the mapping of store fields for offsite providers

## Why?
We need to send store name to bigpay so we can add it to the merchant_transaction_id in bluesnapv2 helper from `bc_[orderId]` to `BC_[storename]_[BCOrderNumber]`.

## Testing / Proof
<img width="624" alt="Screen Shot 2021-07-20 at 20 10 59" src="https://user-images.githubusercontent.com/4503787/126414815-0de5341d-aedd-4bf9-9972-87f390c8a56e.png">

## Dependency of
[Bigpay](https://github.com/bigcommerce/bigpay/pull/4128)

ping @bigcommerce/apex-integrations @bigcommerce/payments @bigcommerce/checkout 
