### PR TITLE
feat(payments): INT-4969  add browser_info to credit_card for Opayo

### DIFF
--- a/src/payment/v1/payment-mappers/payment-mapper.js
+++ b/src/payment/v1/payment-mappers/payment-mapper.js
@@ -74,6 +74,7 @@ export default class PaymentMapper {
             });
         } else {
             objectAssign(payload, {
+                browser_info: payment.browser_info,
                 credit_card: this.mapToCreditCard(data),
             });
         }

--- a/test/payment/v1/payment-mappers/payment-mapper.spec.js
+++ b/test/payment/v1/payment-mappers/payment-mapper.spec.js
@@ -50,22 +50,20 @@ describe('PaymentMapper', () => {
     });
 
     it('maps the input object into a payment object with credit card and browser info data', () => {
-        const browser_info = {
-            color_depth: 24,
-            java_enabled: false,
-            language: 'en-US',
-            screen_height: 400,
-            screen_width: 400,
-            time_zone_offset: 360,
-        }
-
-        const output = paymentMapper.mapToPayment({
-            ...data, 
+        data = merge({}, data, {
             payment: {
                 ...data.payment,
-                browser_info,
-            } 
+                browser_info: {
+                    color_depth: 24,
+                    java_enabled: false,
+                    language: 'en-US',
+                    screen_height: 400,
+                    screen_width: 400,
+                    time_zone_offset: 360,
+                },
+            },
         });
+        const output = paymentMapper.mapToPayment(data);
 
         expect(output).toEqual({
             credit_card: {
@@ -78,7 +76,7 @@ describe('PaymentMapper', () => {
                 three_d_secure: data.payment.threeDSecure,
                 hosted_form_nonce: data.payment.hostedFormNonce,
             },
-            browser_info,
+            browser_info: data.payment.browser_info,
             device: {
                 fingerprint_id: data.orderMeta.deviceFingerprint,
             },

--- a/test/payment/v1/payment-mappers/payment-mapper.spec.js
+++ b/test/payment/v1/payment-mappers/payment-mapper.spec.js
@@ -49,6 +49,47 @@ describe('PaymentMapper', () => {
         });
     });
 
+    it('maps the input object into a payment object with credit card and browser info data', () => {
+        const browser_info = {
+            color_depth: 24,
+            java_enabled: false,
+            language: 'en-US',
+            screen_height: 400,
+            screen_width: 400,
+            time_zone_offset: 360,
+        }
+
+        const output = paymentMapper.mapToPayment({
+            ...data, 
+            payment: {
+                ...data.payment,
+                browser_info,
+            } 
+        });
+
+        expect(output).toEqual({
+            credit_card: {
+                account_name: data.payment.ccName,
+                number: data.payment.ccNumber,
+                month: parseInt(data.payment.ccExpiry.month, 10),
+                verification_value: data.payment.ccCvv,
+                year: parseInt(data.payment.ccExpiry.year, 10),
+                customer_code: data.payment.ccCustomerCode,
+                three_d_secure: data.payment.threeDSecure,
+                hosted_form_nonce: data.payment.hostedFormNonce,
+            },
+            browser_info,
+            device: {
+                fingerprint_id: data.orderMeta.deviceFingerprint,
+            },
+            device_info: data.payment.deviceSessionId,
+            gateway: data.paymentMethod.id,
+            notify_url: data.order.callbackUrl,
+            return_url: data.paymentMethod.returnUrl,
+            vault_payment_instrument: data.payment.shouldSaveInstrument,
+        });
+    });
+
     it('maps the input object into a payment object with credit card token', () => {
         data = merge({}, data, {
             paymentMethod: {


### PR DESCRIPTION
## What? [INT-4969](https://jira.bigcommerce.com/browse/INT-4969)

add browser_info to credit_card for Opayo

## Why?

In order to authenticate shoppers via 3DS2 or 3DS1 when they checkout using Opayo Direct so that can be adhere to PSD2 regulation

## Testing / Proof

### 3DS v2
![Untitled_ Jan 28, 2022 2_02 PM](https://user-images.githubusercontent.com/69221626/151614238-dbad9e68-a6fb-4933-912b-2386818836df.gif)

### fallback to 3DS v1
![Untitled_ Jan 28, 2022 2_06 PM](https://user-images.githubusercontent.com/69221626/151614366-175c6b6b-50a4-4623-9880-40df377c08e9.gif)

## Depends on


## Dependency of

[CHECKOUT-SDK-JS](https://github.com/bigcommerce/checkout-sdk-js/pull/1331)

@bigcommerce/apex-integrations @bigcommerce/checkout 