### PR TITLE
feat(payments): PAYMENTS-7706 Update the payment submitter to use the PPSDK endpoint

### DIFF
--- a/src/payment/payment-method-types.js
+++ b/src/payment/payment-method-types.js
@@ -1,2 +1,3 @@
 export const CREDIT_CARD = 'credit-card';
 export const MULTI_OPTION = 'multi-option';
+export const PPSDK_CREDIT_CARD = 'card';

--- a/src/payment/payment-submitter.js
+++ b/src/payment/payment-submitter.js
@@ -1,4 +1,4 @@
-import { API } from './payment-types';
+import { API, SDK } from './payment-types';
 import PayloadMapper from './v1/payment-mappers/payload-mapper';
 import RequestSender from '../common/http-request/request-sender';
 import UrlHelper from './url-helper';
@@ -51,12 +51,12 @@ export default class PaymentSubmitter {
     submitPayment(data, callback) {
         const { paymentMethod = {} } = data;
 
-        if (paymentMethod.type !== API) {
+        if (paymentMethod.type !== API && paymentMethod.type !== SDK) {
             throw new Error(`${paymentMethod.type} is not supported.`);
         }
 
         const payload = this.payloadMapper.mapToPayload(data);
-        const url = this.urlHelper.getPaymentUrl();
+        const url = paymentMethod.type === SDK ? this.urlHelper.getPpsdkPaymentUrl() : this.urlHelper.getPaymentUrl();
         const options = {
             headers: this.payloadMapper.mapToHeaders(data),
         };

--- a/src/payment/payment-submitter.js
+++ b/src/payment/payment-submitter.js
@@ -1,6 +1,7 @@
+import RequestSender from '../common/http-request/request-sender';
 import { API, SDK } from './payment-types';
 import PayloadMapper from './v1/payment-mappers/payload-mapper';
-import RequestSender from '../common/http-request/request-sender';
+import PpsdkPayloadMapper from './ppsdk/payment-mappers/ppsdk-payload-mapper';
 import UrlHelper from './url-helper';
 
 export default class PaymentSubmitter {
@@ -12,17 +13,19 @@ export default class PaymentSubmitter {
         const urlHelper = UrlHelper.create(config);
         const requestSender = RequestSender.create();
         const payloadMapper = PayloadMapper.create();
+        const ppsdkPayloadMapper = PpsdkPayloadMapper.create();
 
-        return new PaymentSubmitter(urlHelper, requestSender, payloadMapper);
+        return new PaymentSubmitter(urlHelper, requestSender, payloadMapper, ppsdkPayloadMapper);
     }
 
     /**
      * @param {UrlHelper} urlHelper
      * @param {RequestSender} requestSender
      * @param {PayloadMapper} payloadMapper
+     * @param {PpsdkPayloadMapper} ppsdkPayloadMapper
      * @returns {void}
      */
-    constructor(urlHelper, requestSender, payloadMapper) {
+    constructor(urlHelper, requestSender, payloadMapper, ppsdkPayloadMapper) {
         /**
          * @private
          * @type {UrlHelper}
@@ -40,6 +43,12 @@ export default class PaymentSubmitter {
          * @type {PayloadMapper}
          */
         this.payloadMapper = payloadMapper;
+
+        /**
+        * @private
+        * @type {PpsdkPayloadMapper}
+        */
+        this.ppsdkPayloadMapper = ppsdkPayloadMapper;
     }
 
     /**
@@ -55,7 +64,7 @@ export default class PaymentSubmitter {
             throw new Error(`${paymentMethod.type} is not supported.`);
         }
 
-        const payload = this.payloadMapper.mapToPayload(data);
+        const payload = paymentMethod.type === SDK ? this.ppsdkPayloadMapper.mapToPayload(data) : this.payloadMapper.mapToPayload(data);
         const url = paymentMethod.type === SDK ? this.urlHelper.getPpsdkPaymentUrl() : this.urlHelper.getPaymentUrl();
         const options = {
             headers: this.payloadMapper.mapToHeaders(data),

--- a/src/payment/payment-types.js
+++ b/src/payment/payment-types.js
@@ -1,3 +1,4 @@
 export const API = 'PAYMENT_TYPE_API';
 export const HOSTED = 'PAYMENT_TYPE_HOSTED';
 export const OFFLINE = 'PAYMENT_TYPE_OFFLINE';
+export const SDK = 'PAYMENT_TYPE_SDK';

--- a/src/payment/ppsdk/payment-mappers/ppsdk-payload-mapper.js
+++ b/src/payment/ppsdk/payment-mappers/ppsdk-payload-mapper.js
@@ -1,0 +1,46 @@
+import { omitNil, toNumber } from '../../../common/utils';
+import { PPSDK_CREDIT_CARD } from '../../payment-method-types';
+
+export default class PpsdkPayloadMapper {
+    /**
+     * @returns {PayloadMapper}
+     */
+    static create() {
+        return new PpsdkPayloadMapper();
+    }
+
+    /**
+     * @param {PaymentRequestData} data
+     * @returns {Object}
+     */
+    mapToPayload(data) {
+        const { payment = {}, paymentMethod } = data;
+
+        return omitNil({
+            instrument: {
+                expires: {
+                    month: payment.ccExpiry ? toNumber(payment.ccExpiry.month) : null,
+                    year: payment.ccExpiry ? toNumber(payment.ccExpiry.year) : null,
+                },
+                name: payment.ccName,
+                number: payment.ccNumber,
+                verification_value: payment.ccCvv,
+                type: PPSDK_CREDIT_CARD,
+            },
+            form_nonce: payment.hostedFormNonce,
+            payment_method_id: paymentMethod.id,
+        });
+    }
+
+    /**
+     * @param {PaymentRequestData} data
+     * @returns {Object}
+     */
+    mapToHeaders(data) {
+        const { authToken } = data;
+
+        return omitNil({
+            Authorization: authToken,
+        });
+    }
+}

--- a/src/payment/url-helper.js
+++ b/src/payment/url-helper.js
@@ -46,6 +46,13 @@ export default class UrlHelper {
     /**
      * @returns {string}
      */
+    getPpsdkPaymentUrl() {
+        return `${this.host}/payments`;
+    }
+
+    /**
+     * @returns {string}
+     */
     getGenerateClientTokenUrl() {
         return `${this.host}/api/v2/public/payments/client_tokens`;
     }

--- a/test/payment/payment-submitter.spec.js
+++ b/test/payment/payment-submitter.spec.js
@@ -6,6 +6,7 @@ import PaymentSubmitter from '../../src/payment/payment-submitter';
 describe('PaymentSubmitter', () => {
     let data;
     let payloadMapper;
+    let ppsdkPayloadMapper;
     let paymentSubmitter;
     let requestSender;
     let transformedData;
@@ -31,7 +32,12 @@ describe('PaymentSubmitter', () => {
             mapToHeaders: jest.fn(() => transformedHeaders),
         };
 
-        paymentSubmitter = new PaymentSubmitter(urlHelper, requestSender, payloadMapper);
+        ppsdkPayloadMapper = {
+            mapToPayload: jest.fn(() => transformedData),
+            mapToHeaders: jest.fn(() => transformedHeaders),
+        };
+
+        paymentSubmitter = new PaymentSubmitter(urlHelper, requestSender, payloadMapper, ppsdkPayloadMapper);
     });
 
     it('creates an instance of PaymentSubmitter', () => {
@@ -42,10 +48,21 @@ describe('PaymentSubmitter', () => {
     });
 
     describe('submitPayment()', () => {
-        it('maps the input data into a payload object required for submitting a payment', () => {
+        it('maps the input data into the correct payload object required for submitting a payment when payment method type is API', () => {
             paymentSubmitter.submitPayment(data, () => {});
 
             expect(payloadMapper.mapToPayload).toHaveBeenCalled();
+        });
+
+        it('maps the input data into the correct payload object required for submitting a payment when payment method type is SDK', () => {
+            data = merge({}, paymentRequestDataMock, {
+                paymentMethod: {
+                    type: SDK,
+                },
+            });
+            paymentSubmitter.submitPayment(data, () => { });
+
+            expect(ppsdkPayloadMapper.mapToPayload).toHaveBeenCalled();
         });
 
         it('posts the request payload containing payment information to the correct URL when payment method type is API', () => {

--- a/test/payment/ppsdk/payment-mappers/ppsdk-payload-mapper.spec.js
+++ b/test/payment/ppsdk/payment-mappers/ppsdk-payload-mapper.spec.js
@@ -1,0 +1,46 @@
+import PpsdkPayloadMapper from '../../../../src/payment/ppsdk/payment-mappers/ppsdk-payload-mapper';
+import paymentRequestDataMock from '../../../mocks/payment-request-data';
+
+describe('PpsdkPayloadMapper', () => {
+    let data;
+    let payloadMapper;
+
+    beforeEach(() => {
+        data = paymentRequestDataMock;
+
+        payloadMapper = new PpsdkPayloadMapper();
+    });
+
+    it('creates an instance of PpsdkPayloadMapper', () => {
+        const instance = PpsdkPayloadMapper.create();
+
+        expect(instance instanceof PpsdkPayloadMapper).toBeTruthy();
+    });
+
+    it('maps the input data into a payload for submitting a payment', () => {
+        const output = payloadMapper.mapToPayload(data);
+
+        expect(output).toEqual({
+            instrument: {
+                expires: {
+                    month: 1,
+                    year: 2018,
+                },
+                name: 'Foo Bar',
+                number: '4007000000027',
+                verification_value: '123',
+                type: 'card',
+            },
+            form_nonce: 'fakeHostedFormNonce',
+            payment_method_id: 'paypalprous',
+        });
+    });
+
+    it('maps the input data into an object containing http headers required for submitting a payment', () => {
+        const output = payloadMapper.mapToHeaders(data);
+
+        expect(output).toEqual({
+            Authorization: data.authToken,
+        });
+    });
+});

--- a/test/payment/url-helper.spec.js
+++ b/test/payment/url-helper.spec.js
@@ -19,6 +19,10 @@ describe('UrlHelper', () => {
         expect(urlHelper.getPaymentUrl()).toEqual(`${host}/api/public/v1/orders/payments`);
     });
 
+    it('returns a URL for submitting PPSDK payments to a PPSDK provider', () => {
+        expect(urlHelper.getPpsdkPaymentUrl()).toEqual(`${host}/payments`);
+    });
+
     it('returns a URL for submitting payments to an offsite provider', () => {
         expect(urlHelper.getOffsitePaymentUrl()).toEqual(`${host}/pay/initialize`);
     });


### PR DESCRIPTION
## What?
Update `PaymentSubmitter` to use the new PPSDK endpoint in case of PPSDK payment.
Also, create a new `PpsdkPayloadMapper` to match the [the new schema](https://github.com/bigcommerce/api-schema/blob/master/bigpay/payments.yaml).

**Note:** 
- Using the new endpoint for SDK credit card payments is behind an experiment `PAYMENTS-6514.integration_type_and_initialisation_strategy`
- Future updates to the PPSDK payment payload transformer may be needed.

## Why?
Needed for the PPSDK payment sub-strategy on checkout.

## Testing / Proof
Unit tests

ping @bigcommerce/payments 
ping @bigcommerce/checkout 
