### PR TITLE
feat(payment): PAYPAL-1487 add PayPal Commerce Venmo

### DIFF
--- a/src/payment/payment-method-ids.js
+++ b/src/payment/payment-method-ids.js
@@ -8,3 +8,4 @@ export const PAYPAL_COMMERCE = 'paypalcommerce';
 export const PAYPAL_COMMERCE_ALTERNATIVE_METHODS = 'paypalcommercealternativemethods';
 export const PAYPAL_COMMERCE_CREDIT = 'paypalcommercecredit';
 export const PAYPAL_COMMERCE_CREDIT_CARDS = 'paypalcommercecreditcards';
+export const PAYPAL_COMMERCE_VENMO = 'paypalcommercevenmo';

--- a/src/payment/payment-method-mappers/payment-method-id-mapper.js
+++ b/src/payment/payment-method-mappers/payment-method-id-mapper.js
@@ -9,6 +9,7 @@ import {
     PAYPAL_COMMERCE_CREDIT,
     PAYPAL_COMMERCE_CREDIT_CARDS,
     PAYPAL_COMMERCE_ALTERNATIVE_METHODS,
+    PAYPAL_COMMERCE_VENMO,
 } from '../payment-method-ids';
 
 /**
@@ -36,6 +37,7 @@ function isPaypalCommercePaymentMethod(id) {
     case PAYPAL_COMMERCE_CREDIT:
     case PAYPAL_COMMERCE_CREDIT_CARDS:
     case PAYPAL_COMMERCE_ALTERNATIVE_METHODS:
+    case PAYPAL_COMMERCE_VENMO:
         return true;
     default:
         return false;

--- a/test/payment/payment-method-mappers/payment-method-id-mapper.spec.js
+++ b/test/payment/payment-method-mappers/payment-method-id-mapper.spec.js
@@ -65,4 +65,9 @@ describe('PaymentMethodIdMapper', () => {
         paymentMethod = { id: PAYMENT_METHODS.PAYPAL_COMMERCE_ALTERNATIVE_METHODS };
         expect(paymentMethodIdMapper.mapToId(paymentMethod)).toEqual(PAYMENT_METHODS.PAYPAL_COMMERCE);
     });
+
+    it('returns "paypalcommerce" if the payment method is "paypalcommercevenmo"', () => {
+        paymentMethod = { id: PAYMENT_METHODS.PAYPAL_COMMERCE_VENMO };
+        expect(paymentMethodIdMapper.mapToId(paymentMethod)).toEqual(PAYMENT_METHODS.PAYPAL_COMMERCE);
+    });
 });


### PR DESCRIPTION
## What?
A separate module was created for the Venmo payment method on the backend side. The common button strategy for all PPCP SPBs has now been expanded. In the future, a separate strategy will be created for each spb, including for Venmo. These tasks are already planned.

## Why?
We need a module for the Venmo payment method to create separate button strategy for it

## Depends on
https://github.com/bigcommerce/bigpay/pull/5495
https://github.com/bigcommerce/bigcommerce/pull/46631
https://github.com/bigcommerce/checkout-js/pull/891
https://github.com/bigcommerce/checkout-sdk-js/pull/1458

## Testing / Proof
New approach
![Screenshot 2022-06-08 at 10 55 56](https://user-images.githubusercontent.com/18176525/172564601-42ecc2f5-d2ad-4746-afee-bc5476962d12.png)

Old approach
![Screenshot 2022-06-08 at 11 01 03](https://user-images.githubusercontent.com/18176525/172564696-e14fa3db-089b-4e9d-8972-96f19d05fdc0.png)

ping {suggested reviewers}
