### PR TITLE
feat(payments): PAYMENTS-8378 Allow sending multiple addresses to trusted_shipping_address endpoint

### DIFF
--- a/src/store/v2/mappers/index.js
+++ b/src/store/v2/mappers/index.js
@@ -30,6 +30,12 @@ export function mapToInstrumentPayload(data = {}) {
  * @return {Object}
  */
 export function mapToTrustedShippingAddressPayload(data = {}) {
+    if (Array.isArray(data.shippingAddress)) {
+        return omitNil({
+            shipping_addresses: data.shippingAddress.map((address) => mapToAddress(address)),
+        });
+    }
+
     return omitNil({
         shipping_address: mapToAddress(data.shippingAddress),
     });

--- a/test/store/v2/mappers/index.spec.js
+++ b/test/store/v2/mappers/index.spec.js
@@ -111,6 +111,35 @@ describe('StoreMapper', () => {
         expect(result).toEqual(expected);
     });
 
+    it('maps the input object into an array of trusted shipping addresses object in case of multiple addresses', () => {
+        const { shippingAddress } = trustedShippingAddressDataMock;
+
+        const result = mapToTrustedShippingAddressPayload({ ...trustedShippingAddressDataMock, shippingAddress: [shippingAddress, shippingAddress] });
+
+        const expectedAddress = {
+            address_line_1: shippingAddress.addressLine1,
+            address_line_2: shippingAddress.addressLine2,
+            city: shippingAddress.city,
+            company: shippingAddress.company,
+            country_code: shippingAddress.countryCode,
+            email: shippingAddress.email,
+            first_name: shippingAddress.firstName,
+            last_name: shippingAddress.lastName,
+            phone: shippingAddress.phone,
+            postal_code: shippingAddress.postCode,
+            state: {
+                code: shippingAddress.provinceCode,
+                name: shippingAddress.province,
+            },
+        };
+
+        const expected = expect.objectContaining({
+            shipping_addresses: [expectedAddress, expectedAddress],
+        });
+
+        expect(result).toEqual(expected);
+    });
+
     it('accepts null and returns an empty shipping address object', () => {
         const result = mapToTrustedShippingAddressPayload();
         const expected = {


### PR DESCRIPTION
## What?
In case of multi-shipping, we want to send an array of addresses to the `trusted_shipping_address` endpoint instead of a single address.

## Why?
This is required to allow vaulting cards with multi-shipping.

## Testing / Proof
Screenshots
**Before**
<img width="1066" alt="Screen Shot 2022-12-22 at 10 36 42 am" src="https://user-images.githubusercontent.com/36555311/209023690-f2bd5814-8fd4-4180-91b6-fb5ad2b9a797.png">

**After (With multiple addresses)**
<img width="1065" alt="Screen Shot 2022-12-30 at 9 32 49 am" src="https://user-images.githubusercontent.com/36555311/210017731-4ed2f5a3-3207-4519-b537-0b9e39a58068.png">

**After (With single address)**
<img width="1066" alt="Screen Shot 2022-12-30 at 9 31 53 am" src="https://user-images.githubusercontent.com/36555311/210017765-30ab4278-4f43-488a-a52b-bc5405f901d4.png">

ping @bigcommerce/payments 
