### PR TITLE
feat(payment): PAYPAL-1882 added temporary PayPalCommerceAlternativeMethodsV2 implementation

### DIFF
--- a/src/payment/payment-method-ids.js
+++ b/src/payment/payment-method-ids.js
@@ -6,6 +6,7 @@ export const BRAINTREE_GOOGLEPAY = 'googlepaybraintree';
 
 export const PAYPAL_COMMERCE = 'paypalcommerce';
 export const PAYPAL_COMMERCE_ALTERNATIVE_METHODS = 'paypalcommercealternativemethods';
+export const PAYPAL_COMMERCE_ALTERNATIVE_METHODS_TEMPORARY = 'paypalcommercealternativemethodsv2';
 export const PAYPAL_COMMERCE_CREDIT = 'paypalcommercecredit';
 export const PAYPAL_COMMERCE_CREDIT_CARDS = 'paypalcommercecreditcards';
 export const PAYPAL_COMMERCE_INLINE = 'paypalcommerceinline';

--- a/src/payment/payment-method-mappers/payment-method-id-mapper.js
+++ b/src/payment/payment-method-mappers/payment-method-id-mapper.js
@@ -9,6 +9,7 @@ import {
     PAYPAL_COMMERCE_CREDIT,
     PAYPAL_COMMERCE_CREDIT_CARDS,
     PAYPAL_COMMERCE_ALTERNATIVE_METHODS,
+    PAYPAL_COMMERCE_ALTERNATIVE_METHODS_TEMPORARY,
     PAYPAL_COMMERCE_INLINE,
     PAYPAL_COMMERCE_VENMO,
 } from '../payment-method-ids';
@@ -71,6 +72,10 @@ export default class PaymentMethodIdMapper {
 
         if (isPaypalCommercePaymentMethod(id)) {
             return PAYPAL_COMMERCE;
+        }
+
+        if (id === PAYPAL_COMMERCE_ALTERNATIVE_METHODS_TEMPORARY) {
+            return PAYPAL_COMMERCE_ALTERNATIVE_METHODS;
         }
 
         return id;

--- a/test/payment/payment-method-mappers/payment-method-id-mapper.spec.js
+++ b/test/payment/payment-method-mappers/payment-method-id-mapper.spec.js
@@ -75,4 +75,9 @@ describe('PaymentMethodIdMapper', () => {
         paymentMethod = { id: PAYMENT_METHODS.PAYPAL_COMMERCE_VENMO };
         expect(paymentMethodIdMapper.mapToId(paymentMethod)).toEqual(PAYMENT_METHODS.PAYPAL_COMMERCE);
     });
+
+    it('returns "paypalcommercealternativemethods" if the payment method is "paypalcommercealternativemethodsv2"', () => {
+        paymentMethod = { id: PAYMENT_METHODS.PAYPAL_COMMERCE_ALTERNATIVE_METHODS_TEMPORARY };
+        expect(paymentMethodIdMapper.mapToId(paymentMethod)).toEqual(PAYMENT_METHODS.PAYPAL_COMMERCE_ALTERNATIVE_METHODS);
+    });
 });


### PR DESCRIPTION
## What?
Added temporary `PayPalCommerceAlternativeMethodsV2` payment method id to convert it to `PayPalCommerceAlternativeMethods`.

## Why?
Bigpay client does not work with experiments. Hence we are providing `PayPalCommerceAlternativeMethodsV2` payment method id to detect whenever `PayPalCommerceAlternativeMethods` provider id should be sent to bigpay.

It is a temporary decision due to refactoring on bigpay

## Testing / Proof
Here is a screenshot of provided request data to bigpay:
<img width="737" alt="Screenshot 2023-01-19 at 13 57 19" src="https://user-images.githubusercontent.com/25133454/213439362-f01b0ac2-35cd-4f72-a6ac-b239b9df11b3.png">

`paypalcommerce` should be returned if `PAYPAL-1883.paypal-commerce-split-gateway` experiment is off
`paypalcommercealternativemethods` should be returned if `PAYPAL-1883.paypal-commerce-split-gateway` experiment is on

## Sibling pr:
checkout-sdk-js: https://github.com/bigcommerce/checkout-sdk-js/pull/1782
bigcommerce: https://github.com/bigcommerce/bigcommerce/pull/50776
