### PR TITLE
refactor(payment): PAYPAL-1921 removed paypalcommercealternativemethods transformer

### DIFF
--- a/src/payment/payment-method-ids.js
+++ b/src/payment/payment-method-ids.js
@@ -6,7 +6,6 @@ export const BRAINTREE_GOOGLEPAY = 'googlepaybraintree';
 
 export const PAYPAL_COMMERCE = 'paypalcommerce';
 export const PAYPAL_COMMERCE_ALTERNATIVE_METHODS = 'paypalcommercealternativemethods';
-export const PAYPAL_COMMERCE_ALTERNATIVE_METHODS_TEMPORARY = 'paypalcommercealternativemethodsv2';
 export const PAYPAL_COMMERCE_CREDIT = 'paypalcommercecredit';
 export const PAYPAL_COMMERCE_CREDIT_CARDS = 'paypalcommercecreditcards';
 export const PAYPAL_COMMERCE_INLINE = 'paypalcommerceinline';

--- a/src/payment/payment-method-mappers/payment-method-id-mapper.js
+++ b/src/payment/payment-method-mappers/payment-method-id-mapper.js
@@ -9,7 +9,6 @@ import {
     PAYPAL_COMMERCE_CREDIT,
     PAYPAL_COMMERCE_CREDIT_CARDS,
     PAYPAL_COMMERCE_ALTERNATIVE_METHODS,
-    PAYPAL_COMMERCE_ALTERNATIVE_METHODS_TEMPORARY,
     PAYPAL_COMMERCE_INLINE,
     PAYPAL_COMMERCE_VENMO,
 } from '../payment-method-ids';
@@ -72,10 +71,6 @@ export default class PaymentMethodIdMapper {
 
         if (isPaypalCommercePaymentMethod(id)) {
             return PAYPAL_COMMERCE;
-        }
-
-        if (id === PAYPAL_COMMERCE_ALTERNATIVE_METHODS_TEMPORARY) {
-            return PAYPAL_COMMERCE_ALTERNATIVE_METHODS;
         }
 
         return id;

--- a/test/payment/payment-method-mappers/payment-method-id-mapper.spec.js
+++ b/test/payment/payment-method-mappers/payment-method-id-mapper.spec.js
@@ -75,9 +75,4 @@ describe('PaymentMethodIdMapper', () => {
         paymentMethod = { id: PAYMENT_METHODS.PAYPAL_COMMERCE_VENMO };
         expect(paymentMethodIdMapper.mapToId(paymentMethod)).toEqual(PAYMENT_METHODS.PAYPAL_COMMERCE);
     });
-
-    it('returns "paypalcommercealternativemethods" if the payment method is "paypalcommercealternativemethodsv2"', () => {
-        paymentMethod = { id: PAYMENT_METHODS.PAYPAL_COMMERCE_ALTERNATIVE_METHODS_TEMPORARY };
-        expect(paymentMethodIdMapper.mapToId(paymentMethod)).toEqual(PAYMENT_METHODS.PAYPAL_COMMERCE_ALTERNATIVE_METHODS);
-    });
 });


### PR DESCRIPTION
## What?
Removed paypalcommercealternativemethods transformer

## Why?
It was created as part of paypalcommerce bigpay refactoring. However we found another way, how to deal with our needs without passing paypalcommercealternativemethods provider id to bigpay

## Testing / Proof
Unit tests
