### PR TITLE
refactor(payment): PAYPAL-2109 removed paypalcommerceinline method id from payments mapper

### DIFF
--- a/src/payment/payment-method-ids.js
+++ b/src/payment/payment-method-ids.js
@@ -8,5 +8,4 @@ export const PAYPAL_COMMERCE = 'paypalcommerce';
 export const PAYPAL_COMMERCE_ALTERNATIVE_METHODS = 'paypalcommercealternativemethods';
 export const PAYPAL_COMMERCE_CREDIT = 'paypalcommercecredit';
 export const PAYPAL_COMMERCE_CREDIT_CARDS = 'paypalcommercecreditcards';
-export const PAYPAL_COMMERCE_INLINE = 'paypalcommerceinline';
 export const PAYPAL_COMMERCE_VENMO = 'paypalcommercevenmo';

--- a/src/payment/payment-method-mappers/payment-method-id-mapper.js
+++ b/src/payment/payment-method-mappers/payment-method-id-mapper.js
@@ -9,7 +9,6 @@ import {
     PAYPAL_COMMERCE_CREDIT,
     PAYPAL_COMMERCE_CREDIT_CARDS,
     PAYPAL_COMMERCE_ALTERNATIVE_METHODS,
-    PAYPAL_COMMERCE_INLINE,
     PAYPAL_COMMERCE_VENMO,
 } from '../payment-method-ids';
 
@@ -38,7 +37,6 @@ function isPaypalCommercePaymentMethod(id) {
     case PAYPAL_COMMERCE_CREDIT:
     case PAYPAL_COMMERCE_CREDIT_CARDS:
     case PAYPAL_COMMERCE_ALTERNATIVE_METHODS:
-    case PAYPAL_COMMERCE_INLINE:
     case PAYPAL_COMMERCE_VENMO:
         return true;
     default:

--- a/test/payment/payment-method-mappers/payment-method-id-mapper.spec.js
+++ b/test/payment/payment-method-mappers/payment-method-id-mapper.spec.js
@@ -66,11 +66,6 @@ describe('PaymentMethodIdMapper', () => {
         expect(paymentMethodIdMapper.mapToId(paymentMethod)).toEqual(PAYMENT_METHODS.PAYPAL_COMMERCE);
     });
 
-    it('returns "paypalcommerce" if the payment method is "paypalcommerceinline"', () => {
-        paymentMethod = { id: PAYMENT_METHODS.PAYPAL_COMMERCE_INLINE };
-        expect(paymentMethodIdMapper.mapToId(paymentMethod)).toEqual(PAYMENT_METHODS.PAYPAL_COMMERCE);
-    });
-
     it('returns "paypalcommerce" if the payment method is "paypalcommercevenmo"', () => {
         paymentMethod = { id: PAYMENT_METHODS.PAYPAL_COMMERCE_VENMO };
         expect(paymentMethodIdMapper.mapToId(paymentMethod)).toEqual(PAYMENT_METHODS.PAYPAL_COMMERCE);


### PR DESCRIPTION
## What?
Removed paypalcommerceinline method id from payments mapper

## Why?
PayPalCommerce Accelerated Checkout V1 feature is deprecated and should be removed.

## Testing / Proof
Unit tests
