### PR TITLE
feat(payment): PAYPAL-2726 added BraintreeAcceleratedCheckout to payment method mapper

### DIFF
--- a/src/payment/payment-method-ids.js
+++ b/src/payment/payment-method-ids.js
@@ -5,6 +5,7 @@ export const BRAINTREE_VISACHECKOUT = 'braintreevisacheckout';
 export const BRAINTREE_LOCAL_METHODS = 'braintreelocalmethods';
 export const BRAINTREE_GOOGLEPAY = 'googlepaybraintree';
 export const BRAINTREE_ACH = 'braintreeach';
+export const BRAINTREE_ACCELERATED_CHECKOUT = 'braintreeacceleratedcheckout';
 
 export const PAYPAL_COMMERCE = 'paypalcommerce';
 export const PAYPAL_COMMERCE_ALTERNATIVE_METHODS = 'paypalcommercealternativemethods';

--- a/src/payment/payment-method-mappers/payment-method-id-mapper.js
+++ b/src/payment/payment-method-mappers/payment-method-id-mapper.js
@@ -6,12 +6,13 @@ import {
     BRAINTREE_PAYPAL_CREDIT,
     BRAINTREE_VISACHECKOUT,
     BRAINTREE_LOCAL_METHODS,
+    BRAINTREE_ACH,
+    BRAINTREE_ACCELERATED_CHECKOUT,
     PAYPAL_COMMERCE,
     PAYPAL_COMMERCE_CREDIT,
     PAYPAL_COMMERCE_CREDIT_CARDS,
     PAYPAL_COMMERCE_ALTERNATIVE_METHODS,
     PAYPAL_COMMERCE_VENMO,
-    BRAINTREE_ACH,
 } from '../payment-method-ids';
 
 /**
@@ -26,6 +27,7 @@ function isBraintreePaymentMethod(id) {
     case BRAINTREE_GOOGLEPAY:
     case BRAINTREE_ACH:
     case BRAINTREE_LOCAL_METHODS:
+    case BRAINTREE_ACCELERATED_CHECKOUT:
         return true;
     default:
         return false;


### PR DESCRIPTION
## What?
Added BraintreeAcceleratedCheckout to payment method mapper

## Why?
To convert BraintreeAcceleratedCheckout to braintree while placing order

## Testing / Proof
Manual tests
