### PR TITLE
chore(common): PAYPAL-000 updated commit-validation rule from payments to payment

### DIFF
--- a/commit-validation.json
+++ b/commit-validation.json
@@ -1,7 +1,7 @@
 {
     "scopes": [
         "common",
-        "payments",
+        "payment",
         "vaulting",
         "instrument"
     ]


### PR DESCRIPTION
## What?
Updated commit-validation rule from payments to payment

## Why?
To keep commit-validation rules the same as in checkout projects

## Testing / Proof
-