### PR TITLE
feat(payment): PAYPAL-2737 added token_type to payment mapper

### DIFF
--- a/src/payment/v1/payment-mappers/payment-mapper.js
+++ b/src/payment/v1/payment-mappers/payment-mapper.js
@@ -120,6 +120,7 @@ export default class PaymentMapper {
             verification_nonce: payment.nonce,
             three_d_secure: payment.threeDSecure,
             hosted_form_nonce: payment.hostedFormNonce,
+            token_type: payment.tokenType,
         });
     }
 

--- a/test/mocks/payment-request-data.js
+++ b/test/mocks/payment-request-data.js
@@ -111,6 +111,7 @@ const paymentRequestDataMock = {
             token: 'aaa.bbb.ccc',
         },
         hostedFormNonce: 'fakeHostedFormNonce',
+        tokenType: 'fakeTokenType',
     },
     paymentMethod: {
         id: 'paypalprous',

--- a/test/payment/v1/payment-mappers/payment-mapper.spec.js
+++ b/test/payment/v1/payment-mappers/payment-mapper.spec.js
@@ -210,6 +210,7 @@ describe('PaymentMapper', () => {
                     credit_card_number_confirmation: data.payment.ccNumber,
                     three_d_secure: data.payment.three_d_secure,
                     hosted_form_nonce: data.payment.hostedFormNonce,
+                    token_type: data.payment.tokenType,
                 },
             }),
         );


### PR DESCRIPTION
## What?
Added token_type to payment mapper

## Why?
To be able to provider tokenType to backend (bigpay) if needed

## Testing / Proof
Manual tests
