### PR TITLE
feat(payment): added bigcommerce_payments provider mapping

### DIFF
--- a/src/payment/payment-method-ids.js
+++ b/src/payment/payment-method-ids.js
@@ -1,3 +1,10 @@
+export const BIGCOMMERCE_PAYMENTS_PAYPAL = 'bigcommerce_payments_paypal';
+export const BIGCOMMERCE_PAYMENTS_PAYLATER = 'bigcommerce_payments_paylater';
+export const BIGCOMMERCE_PAYMENTS_CREDIT_CARDS = 'bigcommerce_payments_creditcards';
+export const BIGCOMMERCE_PAYMENTS_FASTLANE = 'bigcommerce_payments_fastlane';
+export const BIGCOMMERCE_PAYMENTS_APMS = 'bigcommerce_payments_apms';
+export const BIGCOMMERCE_PAYMENTS_VENMO = 'bigcommerce_payments_venmo';
+
 export const BRAINTREE = 'braintree';
 export const BRAINTREE_PAYPAL = 'braintreepaypal';
 export const BRAINTREE_PAYPAL_CREDIT = 'braintreepaypalcredit';

--- a/src/payment/payment-method-mappers/payment-method-id-mapper.js
+++ b/src/payment/payment-method-mappers/payment-method-id-mapper.js
@@ -1,5 +1,11 @@
 import { MULTI_OPTION } from '../payment-method-types';
 import {
+    BIGCOMMERCE_PAYMENTS_PAYPAL,
+    BIGCOMMERCE_PAYMENTS_PAYLATER,
+    BIGCOMMERCE_PAYMENTS_CREDIT_CARDS,
+    BIGCOMMERCE_PAYMENTS_FASTLANE,
+    BIGCOMMERCE_PAYMENTS_APMS,
+    BIGCOMMERCE_PAYMENTS_VENMO,
     BRAINTREE,
     BRAINTREE_GOOGLEPAY,
     BRAINTREE_PAYPAL,
@@ -52,6 +58,23 @@ function isPaypalCommercePaymentMethod(id) {
     }
 }
 
+/**
+ * @param {string} id
+ * @return {Boolean}
+ */
+function isBigCommercePaymentsPayPalPaymentMethod(id) {
+    switch (id) {
+    case BIGCOMMERCE_PAYMENTS_PAYLATER:
+    case BIGCOMMERCE_PAYMENTS_CREDIT_CARDS:
+    case BIGCOMMERCE_PAYMENTS_FASTLANE:
+    case BIGCOMMERCE_PAYMENTS_APMS:
+    case BIGCOMMERCE_PAYMENTS_VENMO:
+        return true;
+    default:
+        return false;
+    }
+}
+
 export default class PaymentMethodIdMapper {
     /**
      * @returns {PaymentMethodIdMapper}
@@ -77,6 +100,10 @@ export default class PaymentMethodIdMapper {
 
         if (isPaypalCommercePaymentMethod(id)) {
             return PAYPAL_COMMERCE;
+        }
+
+        if (isBigCommercePaymentsPayPalPaymentMethod(id)) {
+            return BIGCOMMERCE_PAYMENTS_PAYPAL;
         }
 
         return id;

--- a/test/payment/payment-method-mappers/payment-method-id-mapper.spec.js
+++ b/test/payment/payment-method-mappers/payment-method-id-mapper.spec.js
@@ -31,6 +31,36 @@ describe('PaymentMethodIdMapper', () => {
         expect(paymentMethodIdMapper.mapToId(paymentMethod)).toEqual(PAYMENT_METHODS.BRAINTREE);
     });
 
+    it('returns "bigcommerce_payments_paypal" if the payment method is "bigcommerce_payments_paypal"', () => {
+        paymentMethod = { id: PAYMENT_METHODS.BIGCOMMERCE_PAYMENTS_PAYPAL };
+        expect(paymentMethodIdMapper.mapToId(paymentMethod)).toEqual(PAYMENT_METHODS.BIGCOMMERCE_PAYMENTS_PAYPAL);
+    });
+
+    it('returns "bigcommerce_payments_paypal" if the payment method is "bigcommerce_payments_paylater"', () => {
+        paymentMethod = { id: PAYMENT_METHODS.BIGCOMMERCE_PAYMENTS_PAYLATER };
+        expect(paymentMethodIdMapper.mapToId(paymentMethod)).toEqual(PAYMENT_METHODS.BIGCOMMERCE_PAYMENTS_PAYPAL);
+    });
+
+    it('returns "bigcommerce_payments_paypal" if the payment method is "bigcommerce_payments_creditcards"', () => {
+        paymentMethod = { id: PAYMENT_METHODS.BIGCOMMERCE_PAYMENTS_CREDIT_CARDS };
+        expect(paymentMethodIdMapper.mapToId(paymentMethod)).toEqual(PAYMENT_METHODS.BIGCOMMERCE_PAYMENTS_PAYPAL);
+    });
+
+    it('returns "bigcommerce_payments_paypal" if the payment method is "bigcommerce_payments_fastlane"', () => {
+        paymentMethod = { id: PAYMENT_METHODS.BIGCOMMERCE_PAYMENTS_FASTLANE };
+        expect(paymentMethodIdMapper.mapToId(paymentMethod)).toEqual(PAYMENT_METHODS.BIGCOMMERCE_PAYMENTS_PAYPAL);
+    });
+
+    it('returns "bigcommerce_payments_paypal" if the payment method is "bigcommerce_payments_apms"', () => {
+        paymentMethod = { id: PAYMENT_METHODS.BIGCOMMERCE_PAYMENTS_APMS };
+        expect(paymentMethodIdMapper.mapToId(paymentMethod)).toEqual(PAYMENT_METHODS.BIGCOMMERCE_PAYMENTS_PAYPAL);
+    });
+
+    it('returns "bigcommerce_payments_paypal" if the payment method is "bigcommerce_payments_venmo"', () => {
+        paymentMethod = { id: PAYMENT_METHODS.BIGCOMMERCE_PAYMENTS_VENMO };
+        expect(paymentMethodIdMapper.mapToId(paymentMethod)).toEqual(PAYMENT_METHODS.BIGCOMMERCE_PAYMENTS_PAYPAL);
+    });
+
     it('returns "braintree" if the payment method is "braintreepaypal"', () => {
         paymentMethod = { id: PAYMENT_METHODS.BRAINTREE_PAYPAL };
         expect(paymentMethodIdMapper.mapToId(paymentMethod)).toEqual(PAYMENT_METHODS.BRAINTREE);


### PR DESCRIPTION
## What?
Added bigcommerce_payments provider mapping

## Why?
To pass valid BCP provider id in payload to bigpay when customer places order using BCP child modules

## Testing / Proof
Unit tests
